### PR TITLE
Feat/03 - 주문(Order) 및 주문 상품(OrderItem) 도메인 설계 및 생성 API 구현

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -2,6 +2,8 @@ addReviewers: true
 
 addAssignees: author
 
+ignoreDraft: true
+
 reviewers:
     - ji-circle
     - githyj-jang
@@ -17,3 +19,4 @@ numberOfAssignees: 1
 # 'wip' 키워드가 제목에 있으면 실행 안 함
 skipKeywords:
     - wip
+    - WIP

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -2,7 +2,7 @@ name: Auto Assign Reviewers
 
 on:
     pull_request:
-        types: [ opened, ready_for_review ]
+        types: [ opened, ready_for_review, edited, reopened ]
 
 jobs:
     assign:

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -2,7 +2,7 @@ name: Auto Assign Reviewers
 
 on:
     pull_request:
-        types: [ opened, ready_for_review, edited, reopened ]
+        types: [ opened, ready_for_review, reopened ]
 
 jobs:
     assign:

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'com.h2database:h2' // 테스트용 메모리 DB 추가
+
+    implementation 'com.michelet:common'
+
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 dependencyManagement {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,6 @@
 rootProject.name = 'order-service'
+
+// 로컬 환경과 CI 환경 모두를 고려한 조건부 포함
+if (file('../common').exists()) {
+    includeBuild('../common')
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,6 @@ rootProject.name = 'order-service'
 // 로컬 환경과 CI 환경 모두를 고려한 조건부 포함
 if (file('../common').exists()) {
     includeBuild('../common')
+} else {
+    throw new GradleException("../common composite build is required. Either provide ../common directory or update com.michelet:common dependency coordinates.")
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,15 +1,51 @@
-= Order Service API Guide
+= Miche-Let 주문 서비스 (Order Service) API 명세서
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs
 :toc: left
-:toclevels: 2
+:toclevels: 4
+:sectlinks:
 
+[[overview]]
+== 개요
+이 문서는 Miche-Let 주문 서비스의 API 명세서입니다. 모든 응답은 `common` 모듈의 `ApiResponse` 형식을 따릅니다.
+
+[[health-check]]
 == Health Check
-주문 서비스의 상태를 확인합니다.
+주문 서비스의 생존 상태를 확인합니다.
 
 === Request
 include::{snippets}/order-controller-test/health-check/http-request.adoc[]
 
 === Response
 include::{snippets}/order-controller-test/health-check/http-response.adoc[]
+
+[[order-management]]
+== 주문 관리 (Order Management)
+
+[[create-order]]
+=== 주문 등록
+
+==== [성공 시나리오]
+사용자가 정상적으로 주문을 생성하는 경우입니다. 주문 시점의 가격과 이름을 스냅샷으로 보존합니다.
+
+===== Request
+include::{snippets}/order-controller-test/create-order-docs/http-request.adoc[]
+
+===== Request Fields
+include::{snippets}/order-controller-test/create-order-docs/request-fields.adoc[]
+
+===== Response
+include::{snippets}/order-controller-test/create-order-docs/http-response.adoc[]
+
+===== Response Fields
+include::{snippets}/order-controller-test/create-order-docs/response-fields.adoc[]
+
+==== [실패 시나리오]
+필수 요청 데이터(userId, items)가 누락된 경우 400 Bad Request를 반환합니다.
+
+===== Request
+include::{snippets}/order-controller-test/create-order-fail-invalid-input/http-request.adoc[]
+
+===== Response
+include::{snippets}/order-controller-test/create-order-fail-invalid-input/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -42,7 +42,7 @@ include::{snippets}/order-controller-test/create-order-docs/http-response.adoc[]
 include::{snippets}/order-controller-test/create-order-docs/response-fields.adoc[]
 
 ==== [실패 시나리오]
-필수 요청 데이터(userId, items)가 누락된 경우 400 Bad Request를 반환합니다.
+필수 요청 데이터(userId, reservationId, restaurantId, orderName, reservedDate, expiredAt, items)가 누락되거나 형식/값 검증을 통과하지 못하면 400 Bad Request를 반환합니다.
 
 ===== Request
 include::{snippets}/order-controller-test/create-order-fail-invalid-input/http-request.adoc[]

--- a/src/main/java/com/michelet/order/application/OrderCommandService.java
+++ b/src/main/java/com/michelet/order/application/OrderCommandService.java
@@ -1,14 +1,49 @@
 package com.michelet.order.application;
 
+import com.michelet.order.application.dto.CreateOrderCommand;
+import com.michelet.order.application.dto.OrderResult;
+import com.michelet.order.domain.model.Order;
+import com.michelet.order.domain.model.OrderItem;
+import com.michelet.order.domain.model.ReceivingMethod;
+import com.michelet.order.domain.repository.OrderRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class OrderCommandService {
+
+    private final OrderRepository orderRepository;
 
     @Transactional(readOnly = true)
     public String checkHealth() {
         return "Order Command Service is Healthy";
+    }
+
+    public OrderResult createOrder(CreateOrderCommand command) {
+        // 1. OrderItem 생성 - 스냅샷
+        List<OrderItem> orderItems = command.items().stream()
+            .map(it -> OrderItem.create(it.optionId(), it.productName(), it.orderPrice(), it.quantity()))
+            .toList();
+
+        // 2. Aggregate Root(Order) 생성 및 계산
+        ReceivingMethod method = command.receivingMethod() != null ?
+            ReceivingMethod.valueOf(command.receivingMethod().toUpperCase()) : ReceivingMethod.PICKUP;
+
+        Order order = Order.create(command.userId(), command.reservationId(),
+            command.restaurantId(),
+            command.orderName(),
+            command.reservedDate(),
+            method,
+            command.expiredAt(),
+            orderItems);
+
+        // 3. 저장
+        Order savedOrder = orderRepository.save(order);
+
+        return new OrderResult(savedOrder.getId(), savedOrder.getStatus().name());
     }
 }

--- a/src/main/java/com/michelet/order/application/OrderCommandService.java
+++ b/src/main/java/com/michelet/order/application/OrderCommandService.java
@@ -30,8 +30,13 @@ public class OrderCommandService {
             .toList();
 
         // 2. Aggregate Root(Order) 생성 및 계산
-        ReceivingMethod method = command.receivingMethod() != null ?
-            ReceivingMethod.valueOf(command.receivingMethod().toUpperCase()) : ReceivingMethod.PICKUP;
+        ReceivingMethod method;
+        try {
+            method = command.receivingMethod() != null ?
+                ReceivingMethod.valueOf(command.receivingMethod().toUpperCase()) : ReceivingMethod.PICKUP;
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("지원하지 않는 수령 방법입니다: " + command.receivingMethod());
+        }
 
         Order order = Order.create(command.userId(), command.reservationId(),
             command.restaurantId(),

--- a/src/main/java/com/michelet/order/application/dto/CreateOrderCommand.java
+++ b/src/main/java/com/michelet/order/application/dto/CreateOrderCommand.java
@@ -1,0 +1,21 @@
+package com.michelet.order.application.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record CreateOrderCommand(
+    UUID userId,
+    UUID reservationId,
+    UUID restaurantId,
+    String orderName,
+    LocalDate reservedDate,
+    String receivingMethod,
+    LocalDateTime expiredAt,
+    List<OrderItemCommand> items
+) {
+    public record OrderItemCommand(UUID optionId, String productName, BigDecimal orderPrice, Integer quantity) {
+    }
+}

--- a/src/main/java/com/michelet/order/application/dto/CreateOrderCommand.java
+++ b/src/main/java/com/michelet/order/application/dto/CreateOrderCommand.java
@@ -33,8 +33,17 @@ public record CreateOrderCommand(
     public record OrderItemCommand(UUID optionId, String productName, BigDecimal orderPrice, Integer quantity) {
         public OrderItemCommand {
             Objects.requireNonNull(optionId, "optionId는 필수입니다.");
-            Objects.requireNonNull(productName, "productName은 필수입니다.");
+            // 빈 문자열(공백 포함) 검증
+            if (productName == null || productName.trim().isEmpty()) {
+                throw new IllegalArgumentException("productName은 필수이며 비어있을 수 없습니다.");
+            }
+
             Objects.requireNonNull(orderPrice, "orderPrice는 필수입니다.");
+            // 가격 0 미만(음수) 검증
+            if (orderPrice.compareTo(BigDecimal.ZERO) < 0) {
+                throw new IllegalArgumentException("orderPrice는 0 이상이어야 합니다.");
+            }
+
             if (quantity == null || quantity <= 0) {
                 throw new IllegalArgumentException("quantity는 1 이상이어야 합니다.");
             }

--- a/src/main/java/com/michelet/order/application/dto/CreateOrderCommand.java
+++ b/src/main/java/com/michelet/order/application/dto/CreateOrderCommand.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 public record CreateOrderCommand(
@@ -16,6 +17,27 @@ public record CreateOrderCommand(
     LocalDateTime expiredAt,
     List<OrderItemCommand> items
 ) {
+    public CreateOrderCommand {
+        Objects.requireNonNull(userId, "userId는 필수입니다.");
+        Objects.requireNonNull(reservationId, "reservationId는 필수입니다.");
+        Objects.requireNonNull(restaurantId, "restaurantId는 필수입니다.");
+        Objects.requireNonNull(orderName, "orderName은 필수입니다.");
+        Objects.requireNonNull(reservedDate, "reservedDate는 필수입니다.");
+        Objects.requireNonNull(expiredAt, "expiredAt은 필수입니다.");
+        if (items == null || items.isEmpty()) {
+            throw new IllegalArgumentException("주문 항목은 최소 1개 이상이어야 합니다.");
+        }
+        items = List.copyOf(items); // 방어적 복사(불변 리스트)
+    }
+
     public record OrderItemCommand(UUID optionId, String productName, BigDecimal orderPrice, Integer quantity) {
+        public OrderItemCommand {
+            Objects.requireNonNull(optionId, "optionId는 필수입니다.");
+            Objects.requireNonNull(productName, "productName은 필수입니다.");
+            Objects.requireNonNull(orderPrice, "orderPrice는 필수입니다.");
+            if (quantity == null || quantity <= 0) {
+                throw new IllegalArgumentException("quantity는 1 이상이어야 합니다.");
+            }
+        }
     }
 }

--- a/src/main/java/com/michelet/order/application/dto/OrderResult.java
+++ b/src/main/java/com/michelet/order/application/dto/OrderResult.java
@@ -1,0 +1,6 @@
+package com.michelet.order.application.dto;
+
+import java.util.UUID;
+
+public record OrderResult(UUID orderId, String status) {
+}

--- a/src/main/java/com/michelet/order/domain/model/Order.java
+++ b/src/main/java/com/michelet/order/domain/model/Order.java
@@ -92,20 +92,16 @@ public class Order extends BaseEntity {
         }
         Order order = new Order(userId, reservationId, restaurantId, orderName, reservedDate, receivingMethod,
             expiredAt);
+        // addOrderItem 내부에서 점진적 덧셈을 하므로 N^2 문제 해결 및 별도 calculateTotalAmount 호출 불필요해짐!
         items.forEach(order::addOrderItem);
-        order.calculateTotalAmount(); // N^2 연산 방지를 위해 항목을 모두 추가한 뒤 마지막에 1회만 계산
         return order;
     }
 
     public void addOrderItem(OrderItem item) {
         this.orderItems.add(item);
         item.assignOrder(this);
-    }
-
-    private void calculateTotalAmount() {
-        this.totalAmount = orderItems.stream()
-            .map(OrderItem::getLinePrice)
-            .reduce(BigDecimal.ZERO, BigDecimal::add);
+        // O(1) 복잡도로 상태 정합성 유지 (N^2 문제 회피)
+        this.totalAmount = this.totalAmount.add(item.getLinePrice());
     }
 
     public void complete() {

--- a/src/main/java/com/michelet/order/domain/model/Order.java
+++ b/src/main/java/com/michelet/order/domain/model/Order.java
@@ -79,7 +79,7 @@ public class Order extends BaseEntity {
         this.userId = userId;
         this.reservationId = reservationId;
         this.restaurantId = restaurantId;
-        this.orderName = orderName;
+        this.orderName = orderName != null ? orderName.trim() : null; //생성자에서 데이터 정규화(trim) 처리
         this.reservedDate = reservedDate;
         this.receivingMethod = receivingMethod != null ? receivingMethod : ReceivingMethod.PICKUP;
         this.expiredAt = expiredAt;
@@ -148,7 +148,6 @@ public class Order extends BaseEntity {
         verifyNotTerminalState(); // 종료 상태(COMPLETED, CANCELED) 검증 추가
 
         if (this.orderItems.remove(item)) {
-            item.assignOrder(null);
             this.totalAmount = this.totalAmount.subtract(item.getLinePrice());
         }
     }

--- a/src/main/java/com/michelet/order/domain/model/Order.java
+++ b/src/main/java/com/michelet/order/domain/model/Order.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -65,6 +66,7 @@ public class Order extends BaseEntity {
     private LocalDate reservedDate;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Getter(AccessLevel.NONE) // 캡슐화를 위해 Lombok 자동 생성 방지
     private List<OrderItem> orderItems = new ArrayList<>();
 
     @Column(nullable = false, precision = 12, scale = 2)
@@ -102,6 +104,19 @@ public class Order extends BaseEntity {
         item.assignOrder(this);
         // O(1) 복잡도로 상태 정합성 유지 (N^2 문제 회피)
         this.totalAmount = this.totalAmount.add(item.getLinePrice());
+    }
+
+    // 외부 노출 시 읽기 전용 리스트 반환을 통한 상태 변경 차단
+    public List<OrderItem> getOrderItems() {
+        return Collections.unmodifiableList(this.orderItems);
+    }
+
+    // 향후 주문 상품 삭제 등 요구사항을 위한 역방향 연관관계 해제 및 정합성 유지 메서드
+    public void removeOrderItem(OrderItem item) {
+        if (this.orderItems.remove(item)) {
+            item.assignOrder(null);
+            this.totalAmount = this.totalAmount.subtract(item.getLinePrice());
+        }
     }
 
     public void complete() {

--- a/src/main/java/com/michelet/order/domain/model/Order.java
+++ b/src/main/java/com/michelet/order/domain/model/Order.java
@@ -110,13 +110,26 @@ public class Order extends BaseEntity {
         return order;
     }
 
+    // 도메인 규칙 검증 헬퍼 메서드 - 종료 상태 확인
+    private void verifyNotTerminalState() {
+        if (this.status == OrderStatus.COMPLETED || this.status == OrderStatus.CANCELED) {
+            throw new IllegalStateException("완료되거나 취소된 주문의 상품은 변경할 수 없습니다.");
+        }
+    }
+
     public void addOrderItem(OrderItem item) {
+        verifyNotTerminalState(); // 종료 상태(COMPLETED, CANCELED) 검증 추가
         // Null 가드 및 소유권 검증
         if (item == null) {
             throw new IllegalArgumentException("추가할 주문 항목(OrderItem)이 null입니다.");
         }
         if (item.getOrder() != null && item.getOrder() != this) {
             throw new IllegalStateException("해당 주문 항목은 이미 다른 주문에 할당되어 있습니다.");
+        }
+
+        // 중복 삽입 방지 가드 추가
+        if (this.orderItems.contains(item) || item.getOrder() == this) {
+            throw new IllegalArgumentException("이미 해당 주문에 추가된 항목입니다.");
         }
 
         this.orderItems.add(item);
@@ -132,6 +145,8 @@ public class Order extends BaseEntity {
 
     // 향후 주문 상품 삭제 등 요구사항을 위한 역방향 연관관계 해제 및 정합성 유지 메서드
     public void removeOrderItem(OrderItem item) {
+        verifyNotTerminalState(); // 종료 상태(COMPLETED, CANCELED) 검증 추가
+
         if (this.orderItems.remove(item)) {
             item.assignOrder(null);
             this.totalAmount = this.totalAmount.subtract(item.getLinePrice());

--- a/src/main/java/com/michelet/order/domain/model/Order.java
+++ b/src/main/java/com/michelet/order/domain/model/Order.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -89,6 +90,16 @@ public class Order extends BaseEntity {
     public static Order create(UUID userId, UUID reservationId, UUID restaurantId, String orderName,
                                LocalDate reservedDate, ReceivingMethod receivingMethod, LocalDateTime expiredAt,
                                List<OrderItem> items) {
+        // 필수 값에 대한 Fail-fast 검증
+        Objects.requireNonNull(userId, "userId는 필수입니다.");
+        Objects.requireNonNull(reservationId, "reservationId는 필수입니다.");
+        Objects.requireNonNull(restaurantId, "restaurantId는 필수입니다.");
+        if (orderName == null || orderName.trim().isEmpty()) {
+            throw new IllegalArgumentException("orderName은 필수이며 비어있을 수 없습니다.");
+        }
+        Objects.requireNonNull(reservedDate, "reservedDate는 필수입니다.");
+        Objects.requireNonNull(expiredAt, "expiredAt은 필수입니다.");
+
         if (items == null || items.isEmpty()) {
             throw new IllegalArgumentException("주문 항목은 최소 1개 이상이어야 합니다.");
         }
@@ -100,6 +111,14 @@ public class Order extends BaseEntity {
     }
 
     public void addOrderItem(OrderItem item) {
+        // Null 가드 및 소유권 검증
+        if (item == null) {
+            throw new IllegalArgumentException("추가할 주문 항목(OrderItem)이 null입니다.");
+        }
+        if (item.getOrder() != null && item.getOrder() != this) {
+            throw new IllegalStateException("해당 주문 항목은 이미 다른 주문에 할당되어 있습니다.");
+        }
+
         this.orderItems.add(item);
         item.assignOrder(this);
         // O(1) 복잡도로 상태 정합성 유지 (N^2 문제 회피)

--- a/src/main/java/com/michelet/order/domain/model/Order.java
+++ b/src/main/java/com/michelet/order/domain/model/Order.java
@@ -1,0 +1,124 @@
+package com.michelet.order.domain.model;
+
+import com.michelet.common.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "p_orders",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_orders_reservation_id", columnNames = {"reservation_id"})
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ReceivingMethod receivingMethod;
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+    @Column(name = "reservation_id", nullable = false)
+    private UUID reservationId;
+
+    @Column(nullable = false)
+    private UUID restaurantId;
+
+    @Column(nullable = false, length = 200)
+    private String orderName;
+
+    @Column(nullable = false)
+    private LocalDate reservedDate;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    @Column(nullable = false, precision = 12, scale = 2)
+    private BigDecimal totalAmount;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Order(UUID userId, UUID reservationId, UUID restaurantId, String orderName, LocalDate reservedDate,
+                  ReceivingMethod receivingMethod, LocalDateTime expiredAt) {
+        this.userId = userId;
+        this.reservationId = reservationId;
+        this.restaurantId = restaurantId;
+        this.orderName = orderName;
+        this.reservedDate = reservedDate;
+        this.receivingMethod = receivingMethod != null ? receivingMethod : ReceivingMethod.PICKUP;
+        this.expiredAt = expiredAt;
+        this.status = OrderStatus.OCCUPIED; // MVP 기준 : 주문 생성 즉시 현장 결제 대기 상태
+        this.totalAmount = BigDecimal.ZERO;
+    }
+
+    public static Order create(UUID userId, UUID reservationId, UUID restaurantId, String orderName,
+                               LocalDate reservedDate, ReceivingMethod receivingMethod, LocalDateTime expiredAt,
+                               List<OrderItem> items) {
+        if (items == null || items.isEmpty()) {
+            throw new IllegalArgumentException("주문 항목은 최소 1개 이상이어야 합니다.");
+        }
+        Order order = new Order(userId, reservationId, restaurantId, orderName, reservedDate, receivingMethod,
+            expiredAt);
+        items.forEach(order::addOrderItem);
+        order.calculateTotalAmount(); // N^2 연산 방지를 위해 항목을 모두 추가한 뒤 마지막에 1회만 계산
+        return order;
+    }
+
+    public void addOrderItem(OrderItem item) {
+        this.orderItems.add(item);
+        item.assignOrder(this);
+    }
+
+    private void calculateTotalAmount() {
+        this.totalAmount = orderItems.stream()
+            .map(OrderItem::getLinePrice)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    public void complete() {
+        if (!this.status.canTransitionTo(OrderStatus.COMPLETED)) {
+            throw new IllegalStateException("주문 완료가 불가능한 상태입니다.");
+        }
+        this.status = OrderStatus.COMPLETED;
+    }
+
+    public void cancel() {
+        if (!this.status.canTransitionTo(OrderStatus.CANCELED)) {
+            throw new IllegalStateException("주문 취소가 불가능한 상태입니다.");
+        }
+        this.status = OrderStatus.CANCELED;
+    }
+}

--- a/src/main/java/com/michelet/order/domain/model/OrderItem.java
+++ b/src/main/java/com/michelet/order/domain/model/OrderItem.java
@@ -29,8 +29,8 @@ public class OrderItem extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "order_id", nullable = false)
     private Order order;
 
     @Column(nullable = false)
@@ -54,6 +54,12 @@ public class OrderItem extends BaseEntity {
     }
 
     public static OrderItem create(UUID optionId, String productName, BigDecimal orderPrice, Integer quantity) {
+        if (optionId == null) {
+            throw new IllegalArgumentException("옵션 ID는 필수입니다.");
+        }
+        if (productName == null || productName.trim().isEmpty()) {
+            throw new IllegalArgumentException("상품명은 필수입니다.");
+        }
         Price validPrice = Price.of(orderPrice);
         Quantity validQuantity = new Quantity(quantity);
         return new OrderItem(optionId, productName, validPrice.value(), validQuantity.value());

--- a/src/main/java/com/michelet/order/domain/model/OrderItem.java
+++ b/src/main/java/com/michelet/order/domain/model/OrderItem.java
@@ -1,0 +1,69 @@
+package com.michelet.order.domain.model;
+
+import com.michelet.common.entity.BaseEntity;
+import com.michelet.order.domain.model.vo.Price;
+import com.michelet.order.domain.model.vo.Quantity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_order_items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @Column(nullable = false)
+    private UUID optionId;
+
+    @Column(nullable = false)
+    private String productName;
+
+    @Column(nullable = false, precision = 12, scale = 2)
+    private BigDecimal orderPrice;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private OrderItem(UUID optionId, String productName, BigDecimal orderPrice, Integer quantity) {
+        this.optionId = optionId;
+        this.productName = productName;
+        this.orderPrice = orderPrice;
+        this.quantity = quantity;
+    }
+
+    public static OrderItem create(UUID optionId, String productName, BigDecimal orderPrice, Integer quantity) {
+        Price validPrice = Price.of(orderPrice);
+        Quantity validQuantity = new Quantity(quantity);
+        return new OrderItem(optionId, productName, validPrice.value(), validQuantity.value());
+    }
+
+    protected void assignOrder(Order order) {
+        this.order = order;
+    }
+
+    public BigDecimal getLinePrice() {
+        return orderPrice.multiply(BigDecimal.valueOf(quantity));
+    }
+}

--- a/src/main/java/com/michelet/order/domain/model/OrderStatus.java
+++ b/src/main/java/com/michelet/order/domain/model/OrderStatus.java
@@ -1,0 +1,25 @@
+package com.michelet.order.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderStatus {
+    PENDING("결제 대기"),
+    OCCUPIED("주문 생성(현장 결제 대기)"),
+    COMPLETED("주문 완료"),
+    CANCELED("주문 취소");
+
+    private final String description;
+
+    /**
+     * 상태 전이 가능 여부 체크 PENDING || (현장 결제) OCCUPIED 상태에서 취소/완료가 가능해야 함
+     */
+    public boolean canTransitionTo(OrderStatus nextStatus) {
+        if (this == PENDING || this == OCCUPIED) {
+            return nextStatus == COMPLETED || nextStatus == CANCELED;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/michelet/order/domain/model/ReceivingMethod.java
+++ b/src/main/java/com/michelet/order/domain/model/ReceivingMethod.java
@@ -1,0 +1,6 @@
+package com.michelet.order.domain.model;
+
+public enum ReceivingMethod {
+    PICKUP,
+    SHIPPING
+}

--- a/src/main/java/com/michelet/order/domain/model/vo/Price.java
+++ b/src/main/java/com/michelet/order/domain/model/vo/Price.java
@@ -1,0 +1,29 @@
+package com.michelet.order.domain.model.vo;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public record Price(BigDecimal value) {
+    private static final BigDecimal MAX_PRICE = new BigDecimal("9999999999.99");
+
+    public Price {
+        if (value == null) {
+            throw new IllegalArgumentException("가격 정보가 누락되었습니다.");
+        }
+        if (value.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("가격은 0원 이상이어야 합니다.");
+        }
+
+        // 정규화: 소수점 2자리 반올림
+        value = value.setScale(2, RoundingMode.HALF_UP);
+
+        // Precision 검증 (12자리 초과 방지)
+        if (value.compareTo(MAX_PRICE) > 0) {
+            throw new IllegalArgumentException("허용 최대 금액(9,999,999,999.99)을 초과했습니다.");
+        }
+    }
+
+    public static Price of(BigDecimal value) {
+        return new Price(value);
+    }
+}

--- a/src/main/java/com/michelet/order/domain/model/vo/Quantity.java
+++ b/src/main/java/com/michelet/order/domain/model/vo/Quantity.java
@@ -1,0 +1,9 @@
+package com.michelet.order.domain.model.vo;
+
+public record Quantity(Integer value) {
+    public Quantity {
+        if (value == null || value <= 0) { // 0 이하일 경우 예외 발생
+            throw new IllegalArgumentException("수량은 1개 이상이어야 합니다.");
+        }
+    }
+}

--- a/src/main/java/com/michelet/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/michelet/order/domain/repository/OrderRepository.java
@@ -1,0 +1,11 @@
+package com.michelet.order.domain.repository;
+
+import com.michelet.order.domain.model.Order;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OrderRepository {
+    Order save(Order order);
+
+    Optional<Order> findById(UUID id);
+}

--- a/src/main/java/com/michelet/order/infrastructure/config/JpaConfig.java
+++ b/src/main/java/com/michelet/order/infrastructure/config/JpaConfig.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.AuditorAware;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 @Configuration
@@ -16,7 +16,7 @@ public class JpaConfig {
     @Profile("!test")
     public AuditorAware<UUID> auditorAware() {
         return () -> Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
-            .filter(Authentication::isAuthenticated)
+            .filter(auth -> auth.isAuthenticated() && !(auth instanceof AnonymousAuthenticationToken)) // 익명 객체 제외 추가
             .map(auth -> {
                 try {
                     // 보안 컨텍스트에서 사용자 ID 추출 (현재는 이름을 UUID로 가정)

--- a/src/main/java/com/michelet/order/infrastructure/config/JpaConfig.java
+++ b/src/main/java/com/michelet/order/infrastructure/config/JpaConfig.java
@@ -1,0 +1,37 @@
+package com.michelet.order.infrastructure.config;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Configuration
+public class JpaConfig {
+
+    @Bean(name = "auditorAware")
+    @Profile("!test")
+    public AuditorAware<UUID> auditorAware() {
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+            .filter(Authentication::isAuthenticated)
+            .map(auth -> {
+                try {
+                    // 보안 컨텍스트에서 사용자 ID 추출 (현재는 이름을 UUID로 가정)
+                    return UUID.fromString(auth.getName());
+                } catch (IllegalArgumentException e) {
+                    return null;
+                }
+            })
+            // 로그인 정보가 없는 시스템 내부 호출 시 사용할 고정 시스템 ID
+            .or(() -> Optional.of(UUID.fromString("00000000-0000-0000-0000-000000000001")));
+    }
+
+    @Bean(name = "auditorAware")
+    @Profile("test")
+    public AuditorAware<UUID> testAuditorAware() {
+        return () -> Optional.of(UUID.fromString("00000000-0000-0000-0000-000000000000"));
+    }
+}

--- a/src/main/java/com/michelet/order/infrastructure/repository/JpaOrderRepository.java
+++ b/src/main/java/com/michelet/order/infrastructure/repository/JpaOrderRepository.java
@@ -1,0 +1,8 @@
+package com.michelet.order.infrastructure.repository;
+
+import com.michelet.order.domain.model.Order;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaOrderRepository extends JpaRepository<Order, UUID> {
+}

--- a/src/main/java/com/michelet/order/infrastructure/repository/OrderRepositoryImpl.java
+++ b/src/main/java/com/michelet/order/infrastructure/repository/OrderRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.michelet.order.infrastructure.repository;
+
+import com.michelet.order.domain.model.Order;
+import com.michelet.order.domain.repository.OrderRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepository {
+    private final JpaOrderRepository jpaOrderRepository;
+
+    @Override
+    public Order save(Order order) {
+        return jpaOrderRepository.save(order);
+    }
+
+    @Override
+    public Optional<Order> findById(UUID id) {
+        return jpaOrderRepository.findById(id);
+    }
+}

--- a/src/main/java/com/michelet/order/presentation/OrderController.java
+++ b/src/main/java/com/michelet/order/presentation/OrderController.java
@@ -28,6 +28,7 @@ public class OrderController {
     @PostMapping
     public ResponseEntity<ApiResponse<OrderResult>> createOrder(@RequestBody @Valid CreateOrderRequest request) {
         OrderResult result = orderCommandService.createOrder(request.toCommand());
-        return ResponseEntity.ok(ApiResponse.ok(result));
+        return ResponseEntity.status(org.springframework.http.HttpStatus.CREATED) // 201 반환
+            .body(ApiResponse.ok(result));
     }
 }

--- a/src/main/java/com/michelet/order/presentation/OrderController.java
+++ b/src/main/java/com/michelet/order/presentation/OrderController.java
@@ -1,9 +1,15 @@
 package com.michelet.order.presentation;
 
+import com.michelet.common.response.ApiResponse;
 import com.michelet.order.application.OrderCommandService;
-import java.util.Map;
+import com.michelet.order.application.dto.OrderResult;
+import com.michelet.order.presentation.dto.CreateOrderRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,11 +21,13 @@ public class OrderController {
     private final OrderCommandService orderCommandService;
 
     @GetMapping("/health")
-    public Map<String, Object> health() {
-        return Map.of(
-            "success", true,
-            "data", orderCommandService.checkHealth(),
-            "message", "Order Command Service is running"
-        );
+    public ApiResponse<String> health() {
+        return ApiResponse.ok(orderCommandService.checkHealth());
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<OrderResult>> createOrder(@RequestBody @Valid CreateOrderRequest request) {
+        OrderResult result = orderCommandService.createOrder(request.toCommand());
+        return ResponseEntity.ok(ApiResponse.ok(result));
     }
 }

--- a/src/main/java/com/michelet/order/presentation/dto/CreateOrderRequest.java
+++ b/src/main/java/com/michelet/order/presentation/dto/CreateOrderRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -26,7 +26,7 @@ public record CreateOrderRequest(
     public record OrderItemRequest(
         @NotNull UUID optionId,
         @NotBlank String productName,
-        @NotNull @Positive BigDecimal orderPrice,
+        @NotNull @PositiveOrZero BigDecimal orderPrice,
         @NotNull @Min(1) Integer quantity
     ) {
     }

--- a/src/main/java/com/michelet/order/presentation/dto/CreateOrderRequest.java
+++ b/src/main/java/com/michelet/order/presentation/dto/CreateOrderRequest.java
@@ -1,0 +1,48 @@
+package com.michelet.order.presentation.dto;
+
+import com.michelet.order.application.dto.CreateOrderCommand;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record CreateOrderRequest(
+    @NotNull UUID userId,
+    @NotNull UUID reservationId,
+    @NotNull UUID restaurantId,
+    @NotBlank String orderName,
+    @NotNull LocalDate reservedDate,
+    String receivingMethod,
+    @NotNull LocalDateTime expiredAt,
+    @NotEmpty List<@Valid OrderItemRequest> items
+) {
+    public record OrderItemRequest(
+        @NotNull UUID optionId,
+        @NotBlank String productName,
+        @NotNull @Positive BigDecimal orderPrice,
+        @NotNull @Min(1) Integer quantity
+    ) {
+    }
+
+    public CreateOrderCommand toCommand() {
+        return new CreateOrderCommand(
+            userId,
+            reservationId,
+            restaurantId,
+            orderName,
+            reservedDate,
+            receivingMethod,
+            expiredAt,
+            items.stream().map(it -> new CreateOrderCommand.OrderItemCommand(
+                it.optionId(), it.productName(), it.orderPrice(), it.quantity()
+            )).toList()
+        );
+    }
+}

--- a/src/test/java/com/michelet/order/application/OrderCommandServiceTest.java
+++ b/src/test/java/com/michelet/order/application/OrderCommandServiceTest.java
@@ -2,6 +2,7 @@ package com.michelet.order.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 import com.michelet.order.application.dto.CreateOrderCommand;
 import com.michelet.order.application.dto.OrderResult;
@@ -58,14 +59,19 @@ class OrderCommandServiceTest {
         assertThat(savedOrder.getOrderItems()).hasSize(2);
 
         // 스냅샷 검증: 상품명이 정확히 저장되었는가
-        assertThat(savedOrder.getOrderItems().get(0).getProductName()).isEqualTo("티본 스테이크");
+        assertThat(savedOrder.getOrderItems())
+            .extracting("productName", "quantity")
+            .containsExactly(
+                tuple("티본 스테이크", 2),
+                tuple("하우스 와인", 3)
+            );
     }
 
     @Test
-    @DisplayName("실패: 주문 상품 리스트가 비어있을 경우 예외가 발생한다")
+    @DisplayName("실패: 주문 상품 리스트가 비어있을 경우 Command 생성 시 예외가 발생한다")
     void createOrder_Fail_EmptyItems() {
-        // given
-        CreateOrderCommand command = new CreateOrderCommand(
+        // when & then: Command 객체를 생성하는 순간 예외가 터져야 함
+        assertThatThrownBy(() -> new CreateOrderCommand(
             UUID.randomUUID(),
             UUID.randomUUID(),
             UUID.randomUUID(),
@@ -73,32 +79,23 @@ class OrderCommandServiceTest {
             LocalDate.now(),
             "PICKUP",
             LocalDateTime.now().plusHours(2),
-            List.of()
-        );
-
-        // when & then
-        assertThatThrownBy(() -> orderCommandService.createOrder(command))
+            List.of() // 빈 리스트 전달
+        ))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("주문 항목은 최소 1개 이상이어야 합니다.");
     }
 
     @Test
-    @DisplayName("실패: 주문 상품의 수량이 0 이하일 경우 VO 검증에 의해 예외가 발생한다")
+    @DisplayName("실패: 주문 상품의 수량이 0 이하일 경우 OrderItemCommand 생성 시 예외가 발생한다")
     void createOrder_Fail_InvalidQuantity() {
-        // given: 수량을 0으로 설정
-        CreateOrderCommand command = new CreateOrderCommand(
+        // when & then: OrderItemCommand 객체를 생성하는 순간 예외가 터져야 함
+        assertThatThrownBy(() -> new CreateOrderCommand.OrderItemCommand(
             UUID.randomUUID(),
-            UUID.randomUUID(),
-            UUID.randomUUID(),
-            "에러 주문",
-            LocalDate.now(),
-            "PICKUP",
-            LocalDateTime.now().plusHours(2),
-            List.of(new CreateOrderCommand.OrderItemCommand(UUID.randomUUID(), "에러 상품", new BigDecimal("1000"), 0))
-        );
-
-        // when & then: OrderItem 생성 시점 혹은 Quantity VO에서 터짐
-        assertThatThrownBy(() -> orderCommandService.createOrder(command))
-            .isInstanceOf(IllegalArgumentException.class);
+            "에러 상품",
+            new BigDecimal("1000"),
+            0 // 수량 0 전달
+        ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("quantity는 1 이상이어야 합니다.");
     }
 }

--- a/src/test/java/com/michelet/order/application/OrderCommandServiceTest.java
+++ b/src/test/java/com/michelet/order/application/OrderCommandServiceTest.java
@@ -1,0 +1,104 @@
+package com.michelet.order.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.michelet.order.application.dto.CreateOrderCommand;
+import com.michelet.order.application.dto.OrderResult;
+import com.michelet.order.domain.model.Order;
+import com.michelet.order.domain.model.OrderStatus;
+import com.michelet.order.domain.repository.OrderRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class OrderCommandServiceTest {
+
+    @Autowired
+    private OrderCommandService orderCommandService;
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Test
+    @DisplayName("성공: 다중 품목 주문 시 총 주문 금액이 정확히 계산되고 저장되어야 한다")
+    void createOrder_Success_Calculation() {
+        // given
+        CreateOrderCommand command = new CreateOrderCommand(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "스테이크 외 1건",
+            LocalDate.now(),
+            "PICKUP",
+            LocalDateTime.now().plusHours(2),
+            List.of(
+                new CreateOrderCommand.OrderItemCommand(UUID.randomUUID(), "티본 스테이크", new BigDecimal("55000"), 2),
+                new CreateOrderCommand.OrderItemCommand(UUID.randomUUID(), "하우스 와인", new BigDecimal("12000"), 3)
+            )
+        );
+
+        // when
+        OrderResult result = orderCommandService.createOrder(command);
+
+        // then: (55000 * 2) + (12000 * 3) = 110000 + 36000 = 146000
+        Order savedOrder = orderRepository.findById(result.orderId()).orElseThrow();
+        assertThat(savedOrder.getTotalAmount()).isEqualByComparingTo(new BigDecimal("146000"));
+        assertThat(savedOrder.getStatus()).isEqualTo(OrderStatus.OCCUPIED);
+        assertThat(savedOrder.getOrderItems()).hasSize(2);
+
+        // 스냅샷 검증: 상품명이 정확히 저장되었는가
+        assertThat(savedOrder.getOrderItems().get(0).getProductName()).isEqualTo("티본 스테이크");
+    }
+
+    @Test
+    @DisplayName("실패: 주문 상품 리스트가 비어있을 경우 예외가 발생한다")
+    void createOrder_Fail_EmptyItems() {
+        // given
+        CreateOrderCommand command = new CreateOrderCommand(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "빈 주문",
+            LocalDate.now(),
+            "PICKUP",
+            LocalDateTime.now().plusHours(2),
+            List.of()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.createOrder(command))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("주문 항목은 최소 1개 이상이어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("실패: 주문 상품의 수량이 0 이하일 경우 VO 검증에 의해 예외가 발생한다")
+    void createOrder_Fail_InvalidQuantity() {
+        // given: 수량을 0으로 설정
+        CreateOrderCommand command = new CreateOrderCommand(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "에러 주문",
+            LocalDate.now(),
+            "PICKUP",
+            LocalDateTime.now().plusHours(2),
+            List.of(new CreateOrderCommand.OrderItemCommand(UUID.randomUUID(), "에러 상품", new BigDecimal("1000"), 0))
+        );
+
+        // when & then: OrderItem 생성 시점 혹은 Quantity VO에서 터짐
+        assertThatThrownBy(() -> orderCommandService.createOrder(command))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/michelet/order/domain/model/OrderTest.java
+++ b/src/test/java/com/michelet/order/domain/model/OrderTest.java
@@ -77,4 +77,17 @@ class OrderTest {
             LocalDateTime.now().plusHours(2),
             List.of(item));
     }
+
+    @Test
+    @DisplayName("실패: 이미 취소된 주문은 완료 상태로 변경할 수 없다")
+    void statusTransition_Fail_CanceledToCompleted() {
+        // given
+        Order order = createDefaultOrder();
+        order.cancel();
+
+        // when & then
+        assertThatThrownBy(order::complete)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("주문 완료가 불가능한 상태입니다.");
+    }
 }

--- a/src/test/java/com/michelet/order/domain/model/OrderTest.java
+++ b/src/test/java/com/michelet/order/domain/model/OrderTest.java
@@ -1,0 +1,80 @@
+package com.michelet.order.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OrderTest {
+
+    @Test
+    @DisplayName("성공: 주문 생성 시 총 금액이 각 항목의 (가격 * 수량) 합계와 일치해야 한다")
+    void createOrder_TotalAmountCalculation() {
+        // given
+        OrderItem item1 = OrderItem.create(UUID.randomUUID(), "상품A", new BigDecimal("10000"), 2); // 20000
+        OrderItem item2 = OrderItem.create(UUID.randomUUID(), "상품B", new BigDecimal("5500"), 3);  // 16500
+
+        // when
+        Order order = Order.create(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "테스트 주문",
+            LocalDate.now(),
+            ReceivingMethod.PICKUP,
+            LocalDateTime.now().plusHours(2),
+            List.of(item1, item2)
+        );
+
+        // then
+        assertThat(order.getTotalAmount()).isEqualByComparingTo(new BigDecimal("36500"));
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.OCCUPIED);
+    }
+
+    @Test
+    @DisplayName("성공: OCCUPIED 상태에서는 COMPLETED 또는 CANCELED로 전이가 가능해야 한다")
+    void statusTransition_Success() {
+        // given
+        Order order = createDefaultOrder();
+
+        // when & then
+        order.complete();
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.COMPLETED);
+
+        Order order2 = createDefaultOrder();
+        order2.cancel();
+        assertThat(order2.getStatus()).isEqualTo(OrderStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("실패: 이미 완료되거나 취소된 주문은 상태를 변경할 수 없다")
+    void statusTransition_Fail() {
+        // given
+        Order order = createDefaultOrder();
+        order.complete();
+
+        // when & then
+        assertThatThrownBy(order::cancel)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("주문 취소가 불가능한 상태입니다.");
+    }
+
+    private Order createDefaultOrder() {
+        OrderItem item = OrderItem.create(UUID.randomUUID(), "기본상품", new BigDecimal("1000"), 1);
+        return Order.create(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "테스트 주문",
+            LocalDate.now(),
+            ReceivingMethod.PICKUP,
+            LocalDateTime.now().plusHours(2),
+            List.of(item));
+    }
+}

--- a/src/test/java/com/michelet/order/infrastructure/repository/OrderAuditingTest.java
+++ b/src/test/java/com/michelet/order/infrastructure/repository/OrderAuditingTest.java
@@ -1,0 +1,52 @@
+package com.michelet.order.infrastructure.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.michelet.common.config.JpaAuditingConfig;
+import com.michelet.order.domain.model.Order;
+import com.michelet.order.domain.model.OrderItem;
+import com.michelet.order.domain.model.ReceivingMethod;
+import com.michelet.order.infrastructure.config.JpaConfig;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import({JpaConfig.class, JpaAuditingConfig.class})
+@ActiveProfiles("test")
+class OrderAuditingTest {
+
+    @Autowired
+    private JpaOrderRepository jpaOrderRepository;
+
+    @Test
+    @DisplayName("성공: 데이터 저장 시 JpaConfig에 설정된 테스트용 UUID가 createdBy에 저장되어야 한다")
+    void auditing_CreatedBy_ShouldMatchTestAuditor() {
+        // given
+        OrderItem item = OrderItem.create(UUID.randomUUID(), "테스트", new BigDecimal("1000"), 1);
+        Order order = Order.create(UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "Auditing 테스트",
+            LocalDate.now(),
+            ReceivingMethod.PICKUP,
+            LocalDateTime.now().plusHours(2),
+            List.of(item));
+
+        // when
+        Order savedOrder = jpaOrderRepository.save(order);
+
+        // then
+        // JpaConfig의 testAuditorAware에서 반환하는 "0000...0000"과 일치해야 함
+        assertThat(savedOrder.getCreatedBy()).isEqualTo(UUID.fromString("00000000-0000-0000-0000-000000000000"));
+        assertThat(savedOrder.getCreatedAt()).isNotNull();
+    }
+}

--- a/src/test/java/com/michelet/order/infrastructure/repository/OrderPersistenceTest.java
+++ b/src/test/java/com/michelet/order/infrastructure/repository/OrderPersistenceTest.java
@@ -1,0 +1,75 @@
+package com.michelet.order.infrastructure.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.michelet.common.config.JpaAuditingConfig;
+import com.michelet.order.domain.model.Order;
+import com.michelet.order.domain.model.OrderItem;
+import com.michelet.order.domain.model.ReceivingMethod;
+import com.michelet.order.infrastructure.config.JpaConfig;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import({JpaConfig.class, JpaAuditingConfig.class})
+@ActiveProfiles("test")
+class OrderPersistenceTest {
+
+    @Autowired
+    private JpaOrderRepository jpaOrderRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("성공: removeOrderItem 호출 후 플러시하면 orphanRemoval에 의해 FK Null 업데이트 없이 정상 삭제(DELETE)된다")
+    void removeOrderItem_ShouldDeleteOrphan() {
+        // given: 2개의 아이템을 가진 주문 생성 (합계 20000원)
+        OrderItem item1 = OrderItem.create(UUID.randomUUID(), "상품A", new BigDecimal("10000"), 1);
+        OrderItem item2 = OrderItem.create(UUID.randomUUID(), "상품B", new BigDecimal("5000"), 2);
+
+        Order order = Order.create(
+            UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+            "   공백 포함 주문명   ", // 테스트용 공백
+            LocalDate.now(), ReceivingMethod.PICKUP, LocalDateTime.now().plusHours(2),
+            List.of(item1, item2)
+        );
+
+        Order savedOrder = jpaOrderRepository.save(order);
+        entityManager.flush();
+        entityManager.clear(); // 영속성 컨텍스트 초기화
+
+        // when: 첫 번째 아이템(상품A) 삭제
+        Order foundOrder = jpaOrderRepository.findById(savedOrder.getId()).orElseThrow();
+        OrderItem targetItem = foundOrder.getOrderItems().get(0); // 상품A 추출
+
+        foundOrder.removeOrderItem(targetItem); // 삭제 메서드 실행
+
+        // flush 시 FK에 Null을 넣는 Update 쿼리가 발생하면 PropertyValueException 발생.
+        // 올바르게 설정되었다면 곧바로 Delete 쿼리가 나감.
+        entityManager.flush();
+        entityManager.clear();
+
+        // then: 데이터베이스 검증
+        Order updatedOrder = jpaOrderRepository.findById(savedOrder.getId()).orElseThrow();
+
+        // 1) 리스트에 1개의 항목만 남음
+        assertThat(updatedOrder.getOrderItems()).hasSize(1);
+
+        // 2) 상품B(5000*2) 금액인 10000원만 남음
+        assertThat(updatedOrder.getTotalAmount()).isEqualByComparingTo(new BigDecimal("10000"));
+
+        // 3) Nitpick 적용 확인: 이름의 공백이 정규화(trim)되었는지
+        assertThat(updatedOrder.getOrderName()).isEqualTo("공백 포함 주문명");
+    }
+}

--- a/src/test/java/com/michelet/order/presentation/OrderControllerTest.java
+++ b/src/test/java/com/michelet/order/presentation/OrderControllerTest.java
@@ -1,22 +1,34 @@
 package com.michelet.order.presentation;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.michelet.order.application.OrderCommandService;
+import com.michelet.order.application.dto.OrderResult;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest(controllers = OrderController.class,
+    excludeAutoConfiguration = {SecurityAutoConfiguration.class})
 @AutoConfigureRestDocs(uriScheme = "http", uriHost = "localhost", uriPort = 19700)
 @ActiveProfiles("test")
 @Import(RestDocsConfig.class)
@@ -25,14 +37,94 @@ public class OrderControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @MockitoBean
+    private OrderCommandService orderCommandService;
+
     @Test
+    @DisplayName("상태 확인: 서비스가 정상 동작하면 200을 반환한다")
     void healthCheck() throws Exception {
+        // given
+        given(orderCommandService.checkHealth()).willReturn("Order Command Service is Healthy");
+
         mockMvc.perform(get("/api/v1/orders/health")
                 .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.message").isString())
-            .andExpect(jsonPath("$.data").isNotEmpty())
-            .andDo(document("{class-name}/{method-name}")); // 명시적으로 추가
+            .andExpect(jsonPath("$.data").value("Order Command Service is Healthy"))
+            .andDo(document("{class-name}/{method-name}"));
+    }
+
+    @Test
+    @DisplayName("성공: 올바른 주문 요청 시 200 OK와 문서를 생성한다")
+    void createOrderDocs() throws Exception {
+        // given
+        UUID mockOrderId = UUID.randomUUID();
+        given(orderCommandService.createOrder(any()))
+            .willReturn(new OrderResult(mockOrderId, "OCCUPIED"));
+
+        String requestJson = """
+            {
+                "userId": "550e8400-e29b-41d4-a716-446655440000",
+                 "reservationId": "550e8400-e29b-41d4-a716-446655440002",
+                                "restaurantId": "550e8400-e29b-41d4-a716-446655440003",
+                                "orderName": "치킨 외 1건",
+                                "reservedDate": "2026-05-01",
+                                "receivingMethod": "PICKUP",
+                                "expiredAt": "2026-05-01T20:00:00",
+                "items": [
+                    {
+                        "optionId": "550e8400-e29b-41d4-a716-446655440001",
+                        "productName": "치킨",
+                        "orderPrice": 20000,
+                        "quantity": 2
+                    }
+                ]
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/orders")
+                .content(requestJson)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.orderId").value(mockOrderId.toString()))
+            .andDo(document("{class-name}/{method-name}",
+                requestFields(
+                    fieldWithPath("userId").type(JsonFieldType.STRING).description("사용자 식별 ID"),
+                    fieldWithPath("reservationId").type(JsonFieldType.STRING).description("예약 식별 ID"),
+                    fieldWithPath("restaurantId").type(JsonFieldType.STRING).description("식당 ID"),
+                    fieldWithPath("orderName").type(JsonFieldType.STRING).description("주문 요약 제목"),
+                    fieldWithPath("reservedDate").type(JsonFieldType.STRING).description("예약 날짜 (YYYY-MM-DD)"),
+                    fieldWithPath("receivingMethod").type(JsonFieldType.STRING).description("수령 방법 (PICKUP/SHIPPING)")
+                        .optional(),
+                    fieldWithPath("expiredAt").type(JsonFieldType.STRING).description("수령 기한 (YYYY-MM-DDTHH:mm:ss)"),
+                    fieldWithPath("items").type(JsonFieldType.ARRAY).description("주문 항목 리스트"),
+                    fieldWithPath("items[].optionId").type(JsonFieldType.STRING).description("상품 옵션 ID"),
+                    fieldWithPath("items[].productName").type(JsonFieldType.STRING).description("주문 시점 상품명"),
+                    fieldWithPath("items[].orderPrice").type(JsonFieldType.NUMBER).description("주문 시점 가격"),
+                    fieldWithPath("items[].quantity").type(JsonFieldType.NUMBER).description("주문 수량")
+                ),
+                responseFields(
+                    fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                    fieldWithPath("data.orderId").type(JsonFieldType.STRING).description("생성된 주문 ID"),
+                    fieldWithPath("data.status").type(JsonFieldType.STRING).description("주문 상태"),
+                    fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간"),
+                    fieldWithPath("traceId").type(JsonFieldType.STRING).description("추적 ID").optional(),
+                    fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드").optional(),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지").optional()
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("실패: 필수 파라미터 누락 시 400 에러를 반환한다")
+    void createOrderFailInvalidInput() throws Exception {
+        String invalidJson = "{\"userId\": null}";
+
+        mockMvc.perform(post("/api/v1/orders")
+                .content(invalidJson)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andDo(document("{class-name}/{method-name}"));
     }
 }

--- a/src/test/java/com/michelet/order/presentation/OrderControllerTest.java
+++ b/src/test/java/com/michelet/order/presentation/OrderControllerTest.java
@@ -2,6 +2,8 @@ package com.michelet.order.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
@@ -85,7 +87,7 @@ public class OrderControllerTest {
         mockMvc.perform(post("/api/v1/orders")
                 .content(requestJson)
                 .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
+            .andExpect(status().isCreated())
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.orderId").value(mockOrderId.toString()))
             .andDo(document("{class-name}/{method-name}",
@@ -126,5 +128,8 @@ public class OrderControllerTest {
                 .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andDo(document("{class-name}/{method-name}"));
+
+        // Validation 실패 시 Service 레이어가 호출되지 않음을 검증
+        verify(orderCommandService, never()).createOrder(any());
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,11 +1,16 @@
 eureka:
     client:
         enabled: false
+        register-with-eureka: false
+        fetch-registry: false
 
 spring:
     cloud:
         discovery:
             enabled: false
+        service-registry:
+            auto-registration:
+                enabled: false
     # JPA 에러 해결을 위한 가짜(메모리) DB 설정
     datasource:
         driver-class-name: org.h2.Driver
@@ -16,3 +21,5 @@ spring:
         database-platform: org.hibernate.dialect.H2Dialect
         hibernate:
             ddl-auto: create-drop
+    main:
+        allow-bean-definition-overriding: true # 혹시 모를 빈 중복 방어

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -21,5 +21,5 @@ spring:
         database-platform: org.hibernate.dialect.H2Dialect
         hibernate:
             ddl-auto: create-drop
-    main:
-        allow-bean-definition-overriding: true # 혹시 모를 빈 중복 방어
+#    main:
+#        allow-bean-definition-overriding: true # 혹시 모를 빈 중복 방어


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 주문 및 주문 상품 도메인 설계: Order와 OrderItem 엔티티를 설계하고 1:N 양방향 연관관계(CascadeType.ALL, orphanRemoval) 매핑
- Price, Quantity VO: 도메인 객체 생성 시점에 금액(0원 이상)과 수량(1개 이상)에 대한 비즈니스 유효성 검증을 캡슐화
- 주문 상태 전이 및 스냅샷 보관: 주문 시점의 상품명과 가격을 OrderItem에 스냅샷 형태로 보관하도록 구현

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #3   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="407" height="62" alt="스크린샷 2026-04-27 오후 10 22 46" src="https://github.com/user-attachments/assets/ebe0db76-446e-4fec-9a5b-50ffd6e2dfb4" />
<img width="306" height="365" alt="스크린샷 2026-04-27 오후 10 23 09" src="https://github.com/user-attachments/assets/a5e614f6-c31c-4353-8bd2-f4f59d37df88" />
<img width="1443" height="823" alt="스크린샷 2026-04-27 오후 10 23 30" src="https://github.com/user-attachments/assets/6a602db6-e5fe-4454-89e7-f036e5b742c4" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

- 현재 PR은 주문 도메인 엔티티의 기초와 DB 저장 로직에 집중되어 있습니다. 타 마이크로서비스(예약 서비스, 인벤토리 서비스)와의 Feign Client 연동(중복 주문 검증, CONFIRMED 예약 검증, 재고 선점 등)은 다음 이슈로 분리하여 이어서 작업할 예정입니다!

- Mapper 등 회의에서 다뤘던 내용들은 추후 반영하겠습니다. 한번에 하려니 파일이 너무 많아져서...ㅠㅠㅠㅠㅠ
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 주문 생성 API 추가 — 주문 등록 시 201로 생성 결과(아이디·상태) 반환.

* **문서**
  * API 명세 한국어화 및 목차 심화, 주문 관리 엔드포인트와 요청/응답 필드 문서화 강화.

* **보안**
  * Spring Security 도입 및 감사(Auditing) 설정 추가.

* **설정**
  * 빌드·공정 보완(공유 빌드 조건 검증), 자동 할당 규칙 개선(초안 무시·WIP 키워드 추가) 및 PR 재오픈 시 트리거 추가.

* **테스트**
  * 도메인·컨트롤러·감사용 테스트 추가로 생성·상태 전환·감사 동작 검증 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->