### PR TITLE
Refactor/11 apply outbox pattern, 스케줄러 연결

### DIFF
--- a/api-test/order.http
+++ b/api-test/order.http
@@ -453,6 +453,7 @@ Authorization: Bearer {{ord_userToken}}
 @dummy_reservation_id = 33333333-3333-3333-3333-333333333333
 @dummy_restaurant_id = 22222222-2222-2222-2222-222222222222
 @dummy_user_id = 0f9cf6c7-402c-41f4-82ad-11cd7c8d7c8b
+@dummy_user_token = ~~
 
 # 카탈로그/인벤토리 Initializer에 세팅해둔 고정 상품 옵션 ID
 @dummy_invalid_option_id = 99999999-9999-9999-9999-999999999999
@@ -462,7 +463,7 @@ Authorization: Bearer {{ord_userToken}}
 # -> 결과: 첫 번째 상품(valid_option_id)을 롤백(RESTORE)하라는 이벤트가 Outbox에 'INIT'으로 꽂혀야 함!
 POST {{gatewayUrl}}/api/v1/orders
 Content-Type: application/json
-Authorization: Bearer {{ord_userToken}}
+Authorization: Bearer {{dummy_user_token}}
 
 {
     "restaurantId": "{{dummy_restaurant_id}}",
@@ -489,7 +490,7 @@ Authorization: Bearer {{ord_userToken}}
 # 2-1) 일단 정상 주문 하나 만들기
 POST {{gatewayUrl}}/api/v1/orders
 Content-Type: application/json
-Authorization: Bearer {{ord_userToken}}
+Authorization: Bearer {{dummy_user_token}}
 
 {
     "restaurantId": "{{dummy_restaurant_id}}",
@@ -513,7 +514,69 @@ Authorization: Bearer {{ord_userToken}}
 ### 2-2) 방금 만든 주문 취소하기
 PATCH {{gatewayUrl}}/api/v1/orders/{{temp_order_id}}/cancel
 Content-Type: application/json
-Authorization: Bearer {{ord_userToken}}
+Authorization: Bearer {{dummy_user_token}}
+
+{
+  "userId": "{{dummy_user_id}}"
+}
+
+
+### 1. 스케줄러 보상 트랜잭션 자동 발행 테스트 - [아웃박스 스케줄러 테스트] 더미 데이터만 사용한 Outbox 스케줄러 자동 발행 확인
+# 1번 아이템은 선점 성공, 2번 아이템은 카탈로그(또는 인벤토리)에서 에러 유발
+# -> DB에 INIT으로 저장된 후, 5초 뒤 스케줄러가 카프카로 쏘고 PUBLISHED로 바꿈.
+POST {{gatewayUrl}}/api/v1/orders
+Content-Type: application/json
+Authorization: Bearer {{dummy_user_token}}
+
+{
+    "restaurantId": "{{dummy_restaurant_id}}",
+    "reservationId": "{{dummy_reservation_id}}",
+    "orderName": "아웃박스 스케줄러 보상 테스트",
+    "receivingMethod": "PICKUP",
+    "expiredAt": "2026-12-31T18:00:00",
+    "items": [
+        {
+            "optionId": "{{ord_option_id_2_1}}",
+            "quantity": 1
+        },
+        {
+            "optionId": "{{dummy_invalid_option_id}}",
+            "quantity": 1
+        }
+    ]
+}
+
+
+### 2. 스케줄러 주문 취소 자동 발행 테스트 - [아웃박스 스케줄러 테스트] 더미 데이터만 사용한 Outbox 스케줄러 자동 발행 확인
+# 2-1) 정상 주문 하나 만들기
+POST {{gatewayUrl}}/api/v1/orders
+Content-Type: application/json
+Authorization: Bearer {{dummy_user_token}}
+
+{
+    "restaurantId": "{{dummy_restaurant_id}}",
+    "reservationId": "{{dummy_reservation_id}}",
+    "orderName": "아웃박스 스케줄러 취소 테스트",
+    "receivingMethod": "PICKUP",
+    "expiredAt": "2026-12-31T18:00:00",
+    "items": [
+        {
+            "optionId": "{{ord_option_id_2_1}}",
+            "quantity": 1
+        }
+    ]
+}
+
+> {%
+    // 방금 만든 더미 주문 ID를 변수에 저장
+    client.global.set("dummy_cancel_order_id", response.body.data.orderId);
+%}
+
+### 2-2) 방금 만든 주문 취소하기
+# -> DB에 INIT으로 저장된 후, 5초 뒤 스케줄러가 카프카로 쏘고 PUBLISHED로 바꿈
+PATCH {{gatewayUrl}}/api/v1/orders/{{dummy_cancel_order_id}}/cancel
+Content-Type: application/json
+Authorization: Bearer {{dummy_user_token}}
 
 {
   "userId": "{{dummy_user_id}}"

--- a/api-test/order.http
+++ b/api-test/order.http
@@ -2,12 +2,12 @@
 @gatewayUrl = http://localhost:19000
 # 취소 검증을 위한 미래 날짜 (레스토랑 1)
 @ord_targetDate_cancel = 2026-05-15
-# 수령 완료 검증을 위한 오늘 날짜 (시스템 기준 5월 9일, 레스토랑 2)
-@ord_targetDate_receive = 2026-05-09
+# 수령 완료 검증을 위한 오늘 날짜 (시스템 기준 5월 12일, 레스토랑 2)
+@ord_targetDate_receive = 2026-05-12
 @ord_courseUnitPrice = 100000.00
 
 # 슬롯 시작, 끝 시간. 테스트할때마다 수정할것!
-@openTime = 23:20:00
+@openTime = 17:20:00
 @closeTime = 23:45:00
 
 ### 1. OWNER 회원가입
@@ -443,3 +443,78 @@ Authorization: Bearer {{ord_userToken}}
         client.log("성공 - 주문 2 RECEIVED 검증 완료");
     });
 %}
+
+
+### ===================================================================
+### [격리 테스트] Outbox 보상 트랜잭션 & 취소 (스케줄러 달기 전)
+### ===================================================================
+
+# 예약 서비스 Initializer에 세팅된 고정 더미 데이터
+@dummy_reservation_id = 33333333-3333-3333-3333-333333333333
+@dummy_restaurant_id = 22222222-2222-2222-2222-222222222222
+@dummy_user_id = 0f9cf6c7-402c-41f4-82ad-11cd7c8d7c8b
+
+# 카탈로그/인벤토리 Initializer에 세팅해둔 고정 상품 옵션 ID
+@dummy_invalid_option_id = 99999999-9999-9999-9999-999999999999
+
+
+### 1. [보상 트랜잭션] 첫 번째는 성공, 두 번째는 고의로 에러 유발
+# -> 결과: 첫 번째 상품(valid_option_id)을 롤백(RESTORE)하라는 이벤트가 Outbox에 'INIT'으로 꽂혀야 함!
+POST {{gatewayUrl}}/api/v1/orders
+Content-Type: application/json
+Authorization: Bearer {{ord_userToken}}
+
+{
+    "restaurantId": "{{dummy_restaurant_id}}",
+    "reservationId": "{{dummy_reservation_id}}",
+    "orderName": "아웃박스 보상 로직 테스트",
+    "receivingMethod": "PICKUP",
+    "expiredAt": "2026-12-31T18:00:00",
+    "items": [
+        {
+            "optionId": "{{ord_option_id_2_1}}",
+            "quantity": 1
+        },
+        {
+            "optionId": "{{dummy_invalid_option_id}}",
+            "quantity": 1
+        }
+    ]
+}
+
+
+### 2. [주문 취소] 정상 주문 하나 만들고 바로 취소하기
+# -> 결과: 취소한 아이템(valid_option_id)을 롤백(RESTORE)하라는 이벤트가 Outbox에 'INIT'으로 꽂혀야 함!
+
+# 2-1) 일단 정상 주문 하나 만들기
+POST {{gatewayUrl}}/api/v1/orders
+Content-Type: application/json
+Authorization: Bearer {{ord_userToken}}
+
+{
+    "restaurantId": "{{dummy_restaurant_id}}",
+    "reservationId": "{{dummy_reservation_id}}",
+    "orderName": "아웃박스 취소 로직 테스트",
+    "receivingMethod": "PICKUP",
+    "expiredAt": "2026-12-31T18:00:00",
+    "items": [
+        {
+            "optionId": "{{ord_option_id_2_1}}",
+            "quantity": 1
+        }
+    ]
+}
+
+> {%
+    // 방금 만든 주문 ID를 변수에 저장
+    client.global.set("temp_order_id", response.body.data.orderId);
+%}
+
+### 2-2) 방금 만든 주문 취소하기
+PATCH {{gatewayUrl}}/api/v1/orders/{{temp_order_id}}/cancel
+Content-Type: application/json
+Authorization: Bearer {{ord_userToken}}
+
+{
+  "userId": "{{dummy_user_id}}"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.kafka:spring-kafka'
 
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
@@ -49,6 +50,7 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'com.h2database:h2'
     testImplementation 'com.h2database:h2' // 테스트용 메모리 DB 추가
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 
     implementation 'com.github.Miche-Let:common:dev-SNAPSHOT'
     implementation 'com.github.Miche-Let:common-auth-webmvc:0.1.5'

--- a/src/main/java/com/michelet/order/OrderServiceApplication.java
+++ b/src/main/java/com/michelet/order/OrderServiceApplication.java
@@ -6,7 +6,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 @EnableFeignClients
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)

--- a/src/main/java/com/michelet/order/application/OrderCommandService.java
+++ b/src/main/java/com/michelet/order/application/OrderCommandService.java
@@ -109,6 +109,8 @@ public class OrderCommandService {
         } catch (Exception e) {
             // 성공적으로 선점했던 내역(reservedStocks)만 순회하며 주문 시도 전체에 대한 성공 아이템에 대해서도 복구 기록을 남김
             log.error("주문 생성 중 예외 발생. 보상 트랜잭션(재고 복구)을 Outbox에 저장합니다. 원인: {}", e.getMessage());
+
+            // 반복문 안쪽에 try-catch를 두어 독립적인 실패 추적 및 계속 진행 보장
             for (InventoryClient.RestoreStockRequest restoreReq : reservedStocks) {
                 try {
                     orderOutboxHelper.appendCompensation(
@@ -118,9 +120,12 @@ public class OrderCommandService {
                         new StockRestoreEventPayload(restoreReq.optionId(), restoreReq.quantity())
                     );
                     log.info("보상 Outbox 저장 완료: 옵션 {} 재고 복구 대기", restoreReq.optionId());
-                } catch (Exception ex) {
-                    log.error("크리티컬: 재고 복구 Outbox 저장 실패 (수동 복구 필요!): optionId={}, quantity={}",
-                        restoreReq.optionId(), restoreReq.quantity(), ex);
+                } catch (Exception outboxEx) {
+                    // 향후 모니터링/알림 시스템 연동을 위한 상세 로그 기록
+                    log.error(
+                        "[CRITICAL ALERT] 보상 트랜잭션 Outbox 저장 실패. 수동 복구 요망! reservationId: {}, optionId: {}, quantity: {}",
+                        command.reservationId(), restoreReq.optionId(), restoreReq.quantity(), outboxEx);
+                    // TODO: Slack, Datadog 알림 발송 등
                 }
             }
             throw e;

--- a/src/main/java/com/michelet/order/application/OrderCommandService.java
+++ b/src/main/java/com/michelet/order/application/OrderCommandService.java
@@ -117,7 +117,8 @@ public class OrderCommandService {
                         "ORDER",
                         command.reservationId().toString(), // Order가 생성되기 전이므로 예약 ID를 Aggregate ID로 사용
                         "STOCK_RESTORE",
-                        new StockRestoreEventPayload(restoreReq.optionId(), restoreReq.quantity())
+                        // UUID.randomUUID()를 통해 고유한 이벤트 식별자(eventId) 발급
+                        new StockRestoreEventPayload(UUID.randomUUID(), restoreReq.optionId(), restoreReq.quantity())
                     );
                     log.info("보상 Outbox 저장 완료: 옵션 {} 재고 복구 대기", restoreReq.optionId());
                 } catch (Exception outboxEx) {
@@ -148,7 +149,7 @@ public class OrderCommandService {
                 "ORDER",
                 order.getId().toString(),
                 "STOCK_RESTORE",
-                new StockRestoreEventPayload(item.getOptionId(), item.getQuantity())
+                new StockRestoreEventPayload(UUID.randomUUID(), item.getOptionId(), item.getQuantity())
             );
             log.info("주문 취소에 따른 재고 복구 Outbox 저장 완료: optionId={}, quantity={}", item.getOptionId(), item.getQuantity());
         }

--- a/src/main/java/com/michelet/order/application/OrderCommandService.java
+++ b/src/main/java/com/michelet/order/application/OrderCommandService.java
@@ -2,6 +2,7 @@ package com.michelet.order.application;
 
 import com.michelet.order.application.dto.CreateOrderCommand;
 import com.michelet.order.application.dto.OrderResult;
+import com.michelet.order.application.dto.StockRestoreEventPayload;
 import com.michelet.order.application.port.out.ReservationValidationPort;
 import com.michelet.order.domain.model.Order;
 import com.michelet.order.domain.model.OrderItem;
@@ -29,6 +30,8 @@ public class OrderCommandService {
     private final InventoryClient inventoryClient;
     private final CatalogClient catalogClient;
 
+    private final OrderOutboxHelper orderOutboxHelper;
+
     @Transactional(readOnly = true)
     public String checkHealth() {
         return "Order Command Service is Healthy";
@@ -47,7 +50,7 @@ public class OrderCommandService {
         List<OrderItem> orderItems = new ArrayList<>();
 
         try {
-            // 0-2. 카탈로그 가격 검증 및 인벤토리 재고 선점
+            // 0-2. 카탈로그 가격 검증 및 인벤토리 재고 선점 (예약 선점은 일단 동기 유지)
             for (CreateOrderCommand.OrderItemCommand item : command.items()) {
                 var catalogRes = catalogClient.validateOption(item.optionId());
                 if (catalogRes == null || catalogRes.data() == null) {
@@ -104,14 +107,19 @@ public class OrderCommandService {
             return new OrderResult(savedOrder.getId(), savedOrder.getStatus().name(), savedOrder.getOrderName());
 
         } catch (Exception e) {
-            // 4. 에러 발생 시 재고 복구 로직
-            log.error("주문 생성 중 예외 발생. 보상 트랜잭션(재고 복구)을 실행합니다. 원인: {}", e.getMessage());
+            // 성공적으로 선점했던 내역(reservedStocks)만 순회하며 주문 시도 전체에 대한 성공 아이템에 대해서도 복구 기록을 남김
+            log.error("주문 생성 중 예외 발생. 보상 트랜잭션(재고 복구)을 Outbox에 저장합니다. 원인: {}", e.getMessage());
             for (InventoryClient.RestoreStockRequest restoreReq : reservedStocks) {
                 try {
-                    inventoryClient.restoreStock(restoreReq);
-                    log.info("보상 완료: 옵션 {} 재고 복구", restoreReq.optionId());
+                    orderOutboxHelper.appendCompensation(
+                        "ORDER",
+                        command.reservationId().toString(), // Order가 생성되기 전이므로 예약 ID를 Aggregate ID로 사용
+                        "STOCK_RESTORE",
+                        new StockRestoreEventPayload(restoreReq.optionId(), restoreReq.quantity())
+                    );
+                    log.info("보상 Outbox 저장 완료: 옵션 {} 재고 복구 대기", restoreReq.optionId());
                 } catch (Exception ex) {
-                    log.error("크리티컬: 재고 복구 실패 (데이터 불일치 발생!): optionId={}, quantity={}",
+                    log.error("크리티컬: 재고 복구 Outbox 저장 실패 (수동 복구 필요!): optionId={}, quantity={}",
                         restoreReq.optionId(), restoreReq.quantity(), ex);
                 }
             }
@@ -130,23 +138,14 @@ public class OrderCommandService {
         // 방문 예정일 이전인지 확인하고 상태 변경 (현재 시점 전달)
         order.cancel(LocalDate.now());
 
-        // 동기 Feign 호출로 재고 복구 (향후 Outbox 패턴으로 전환 예정)
-        // 실패한 아이템 전체를 수집 후 한 번에 예외 발생 (부분 실패 관측성 향상)
-        List<UUID> failedOptionIds = new ArrayList<>();
         for (OrderItem item : order.getOrderItems()) {
-            try {
-                inventoryClient.restoreStock(
-                    new InventoryClient.RestoreStockRequest(item.getOptionId(), item.getQuantity()));
-                log.info("주문 취소로 인한 재고 복구 완료: optionId={}, quantity={}", item.getOptionId(), item.getQuantity());
-            } catch (Exception e) {
-                log.error("주문 취소에 따른 재고 복구 실패 (데이터 불일치 위험): optionId={}", item.getOptionId(), e);
-                failedOptionIds.add(item.getOptionId());
-            }
-        }
-
-        if (!failedOptionIds.isEmpty()) {
-            throw new IllegalStateException(
-                "재고 복구 통신 중 오류가 발생하여 취소할 수 없습니다. 실패한 optionIds: " + failedOptionIds);
+            orderOutboxHelper.append(
+                "ORDER",
+                order.getId().toString(),
+                "STOCK_RESTORE",
+                new StockRestoreEventPayload(item.getOptionId(), item.getQuantity())
+            );
+            log.info("주문 취소에 따른 재고 복구 Outbox 저장 완료: optionId={}, quantity={}", item.getOptionId(), item.getQuantity());
         }
     }
 

--- a/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
@@ -1,0 +1,63 @@
+package com.michelet.order.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.michelet.order.domain.model.OrderOutbox;
+import com.michelet.order.domain.repository.OrderOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderOutboxHelper {
+
+    private final OrderOutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
+
+    // 1. 주문 취소 등 정상 흐름에서 사용 (현재 트랜잭션에 합류)
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void append(
+        String aggregateType,
+        String aggregateId,
+        String eventType,
+        Object payloadObj
+    ) {
+        saveOutbox(aggregateType, aggregateId, eventType, payloadObj);
+    }
+
+    // 2. 주문 생성 실패 시 보상 트랜잭션에서 사용 (기존 롤백 트랜잭션과 분리되어 무조건 커밋됨)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void appendCompensation(
+        String aggregateType,
+        String aggregateId,
+        String eventType,
+        Object payloadObj
+    ) {
+        saveOutbox(aggregateType, aggregateId, eventType, payloadObj);
+    }
+
+    private void saveOutbox(
+        String aggregateType,
+        String aggregateId,
+        String eventType,
+        Object payloadObj
+    ) {
+        try {
+            String payloadJson = objectMapper.writeValueAsString(payloadObj);
+            OrderOutbox outbox = OrderOutbox.builder()
+                .aggregateType(aggregateType)
+                .aggregateId(aggregateId)
+                .eventType(eventType)
+                .payload(payloadJson)
+                .build();
+            outboxRepository.save(outbox);
+        } catch (JsonProcessingException e) {
+            log.error("Outbox 페이로드 직렬화 실패. aggregateId={}, eventType={}", aggregateId, eventType, e);
+            throw new RuntimeException("Outbox 이벤트 생성 중 오류가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.michelet.order.domain.model.OrderOutbox;
 import com.michelet.order.domain.model.OutboxStatus;
 import com.michelet.order.domain.repository.OrderOutboxRepository;
+import jakarta.annotation.PostConstruct;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,8 +25,15 @@ public class OrderOutboxHelper {
     @Value("${order.outbox.max-retries:3}")
     private int maxRetries;
 
-    // 1. 주문 생성/취소 등 정상 흐름 (실패 시 트랜잭션 롤백 필요)
-    @Transactional(propagation = Propagation.REQUIRED)
+    @PostConstruct
+    public void validateMaxRetries() {
+        if (maxRetries < 1) {
+            throw new IllegalStateException("order.outbox.max-retries must be >= 1");
+        }
+    }
+
+    // 1. 주문 생성/취소 등 정상 흐름 (호출 측에 활성 트랜잭션이 없으면 즉시 실패하여 원자성 강제)
+    @Transactional(propagation = Propagation.MANDATORY)
     public void append(
         String aggregateType,
         String aggregateId,

--- a/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
@@ -30,7 +30,7 @@ public class OrderOutboxHelper {
         saveOutbox(aggregateType, aggregateId, eventType, payloadObj, false);
     }
 
-    // 2. 보상 트랜잭션 흐름 (반드시 DB에 기록을 남겨야 함)
+    // 2. 보상 트랜잭션 흐름 (무슨 일이 있어도 DB에 기록을 남겨야 함)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void appendCompensation(
         String aggregateType,
@@ -95,8 +95,15 @@ public class OrderOutboxHelper {
                     .eventType(eventType + "_SERIALIZATION_ERROR")
                     .payload(errorPayload)
                     .build();
-                outboxRepository.save(errorOutbox);
-                log.error("[CRITICAL] 보상 트랜잭션 이벤트 직렬화 실패로 Fallback 에러 이벤트를 적재했습니다. 수동 확인 요망!");
+
+                // 저장된 객체를 변수로 받아 ID를 로그에 함께 출력
+                OrderOutbox savedErrorOutbox = outboxRepository.save(errorOutbox);
+                log.error(
+                    "[CRITICAL] 보상 트랜잭션 이벤트 직렬화 실패로 fallback 에러 이벤트를 적재했습니다. outboxId={}, aggregateId={}, eventType={}. 수동 확인이 필요합니다.",
+                    savedErrorOutbox.getId(),
+                    aggregateId,
+                    eventType
+                );
             } else {
                 // 정상 흐름일 경우 예외를 던져서 트랜잭션 롤백 유도
                 throw new RuntimeException("Outbox 이벤트 생성 중 오류가 발생했습니다.", e);

--- a/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
@@ -3,10 +3,12 @@ package com.michelet.order.application;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.michelet.order.domain.model.OrderOutbox;
+import com.michelet.order.domain.model.OutboxStatus;
 import com.michelet.order.domain.repository.OrderOutboxRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +20,9 @@ public class OrderOutboxHelper {
 
     private final OrderOutboxRepository outboxRepository;
     private final ObjectMapper objectMapper;
+
+    @Value("${order.outbox.max-retries:3}")
+    private int maxRetries;
 
     // 1. 주문 생성/취소 등 정상 흐름 (실패 시 트랜잭션 롤백 필요)
     @Transactional(propagation = Propagation.REQUIRED)
@@ -46,10 +51,35 @@ public class OrderOutboxHelper {
     public void markAsPublished(UUID outboxId) {
         outboxRepository.findById(outboxId).ifPresentOrElse(
             outbox -> {
+                // 비동기 처리 중 혹시 모를 중복 업데이트 방어
+                if (outbox.getStatus() == OutboxStatus.PUBLISHED) {
+                    return;
+                }
+
                 outbox.markAsPublished();
                 outboxRepository.save(outbox);
             },
             () -> log.warn("[Order Outbox] 발행 성공 후 상태 변경 대상이 없습니다. outboxId={}", outboxId)
+        );
+    }
+
+    // 비동기 카프카 전송 실패 시 재시도 횟수를 올리고 3회 초과 시 FAILED 처리하는 로직
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleFailure(UUID outboxId) {
+        outboxRepository.findById(outboxId).ifPresentOrElse(
+            outbox -> {
+                if (outbox.getStatus() != OutboxStatus.INIT) {
+                    return;
+                }
+
+                outbox.incrementRetryCount();
+                if (outbox.getRetryCount() >= maxRetries) {
+                    outbox.markAsFailed();
+                    log.error("[CRITICAL] Order Outbox 최대 재시도 횟수 초과. FAILED 상태로 마킹. 수동 조치 요망. outboxId={}", outboxId);
+                }
+                outboxRepository.save(outbox);
+            },
+            () -> log.warn("[Order Outbox] 실패 처리 대상이 없습니다. outboxId={}", outboxId)
         );
     }
 

--- a/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
@@ -3,7 +3,8 @@ package com.michelet.order.application;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.michelet.order.domain.model.OrderOutbox;
-import com.michelet.order.domain.repository.OrderOutboxRepository;
+import com.michelet.order.infrastructure.repository.JpaOrderOutboxRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -15,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OrderOutboxHelper {
 
-    private final OrderOutboxRepository outboxRepository;
+    private final JpaOrderOutboxRepository outboxRepository;
     private final ObjectMapper objectMapper;
 
     // 1. 주문 취소 등 정상 흐름에서 사용 (현재 트랜잭션에 합류)
@@ -38,6 +39,12 @@ public class OrderOutboxHelper {
         Object payloadObj
     ) {
         saveOutbox(aggregateType, aggregateId, eventType, payloadObj);
+    }
+
+    // 스케줄러가 카프카 전송 성공 후 상태를 바꿀 때 사용하는 개별 독립 트랜잭션
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markAsPublished(UUID outboxId) {
+        outboxRepository.findById(outboxId).ifPresent(OrderOutbox::markAsPublished);
     }
 
     private void saveOutbox(

--- a/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
@@ -3,7 +3,7 @@ package com.michelet.order.application;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.michelet.order.domain.model.OrderOutbox;
-import com.michelet.order.infrastructure.repository.JpaOrderOutboxRepository;
+import com.michelet.order.domain.repository.OrderOutboxRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OrderOutboxHelper {
 
-    private final JpaOrderOutboxRepository outboxRepository;
+    private final OrderOutboxRepository outboxRepository;
     private final ObjectMapper objectMapper;
 
     // 1. 주문 생성/취소 등 정상 흐름 (실패 시 트랜잭션 롤백 필요)
@@ -83,7 +83,8 @@ public class OrderOutboxHelper {
                 .build();
             outboxRepository.save(outbox);
         } catch (JsonProcessingException e) {
-            log.error("Outbox 페이로드 직렬화 실패. aggregateId={}, eventType={}", aggregateId, eventType, e);
+            log.error("Outbox 페이로드 직렬화 실패. aggregateId={}, eventType={}, error={}",
+                aggregateId, eventType, e.getMessage(), e);
 
             // 보상 트랜잭션인 경우 예외를 삼키고 에러 페이로드로 대체 저장하여 유실 방지
             if (isCompensation) {

--- a/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
@@ -19,7 +19,7 @@ public class OrderOutboxHelper {
     private final JpaOrderOutboxRepository outboxRepository;
     private final ObjectMapper objectMapper;
 
-    // 1. 주문 취소 등 정상 흐름에서 사용 (현재 트랜잭션에 합류)
+    // 1. 주문 생성/취소 등 정상 흐름 (실패 시 트랜잭션 롤백 필요)
     @Transactional(propagation = Propagation.REQUIRED)
     public void append(
         String aggregateType,
@@ -27,10 +27,10 @@ public class OrderOutboxHelper {
         String eventType,
         Object payloadObj
     ) {
-        saveOutbox(aggregateType, aggregateId, eventType, payloadObj);
+        saveOutbox(aggregateType, aggregateId, eventType, payloadObj, false);
     }
 
-    // 2. 주문 생성 실패 시 보상 트랜잭션에서 사용 (기존 롤백 트랜잭션과 분리되어 무조건 커밋됨)
+    // 2. 보상 트랜잭션 흐름 (반드시 DB에 기록을 남겨야 함)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void appendCompensation(
         String aggregateType,
@@ -38,7 +38,7 @@ public class OrderOutboxHelper {
         String eventType,
         Object payloadObj
     ) {
-        saveOutbox(aggregateType, aggregateId, eventType, payloadObj);
+        saveOutbox(aggregateType, aggregateId, eventType, payloadObj, true);
     }
 
     // 3. 스케줄러가 카프카 전송 성공 후 상태를 바꿀 때 사용하는 개별 독립 트랜잭션
@@ -57,7 +57,8 @@ public class OrderOutboxHelper {
         String aggregateType,
         String aggregateId,
         String eventType,
-        Object payloadObj
+        Object payloadObj,
+        boolean isCompensation // 보상 트랜잭션 여부 플래그
     ) {
         if (aggregateType == null || aggregateType.isBlank()) {
             throw new IllegalArgumentException("aggregateType은 필수입니다.");
@@ -83,7 +84,23 @@ public class OrderOutboxHelper {
             outboxRepository.save(outbox);
         } catch (JsonProcessingException e) {
             log.error("Outbox 페이로드 직렬화 실패. aggregateId={}, eventType={}", aggregateId, eventType, e);
-            throw new RuntimeException("Outbox 이벤트 생성 중 오류가 발생했습니다.", e);
+
+            // 보상 트랜잭션인 경우 예외를 삼키고 에러 페이로드로 대체 저장하여 유실 방지
+            if (isCompensation) {
+                String errorPayload = String.format("{\"error\":\"serialization_failed\",\"class\":\"%s\"}",
+                    payloadObj.getClass().getName());
+                OrderOutbox errorOutbox = OrderOutbox.builder()
+                    .aggregateType(aggregateType)
+                    .aggregateId(aggregateId)
+                    .eventType(eventType + "_SERIALIZATION_ERROR")
+                    .payload(errorPayload)
+                    .build();
+                outboxRepository.save(errorOutbox);
+                log.error("[CRITICAL] 보상 트랜잭션 이벤트 직렬화 실패로 Fallback 에러 이벤트를 적재했습니다. 수동 확인 요망!");
+            } else {
+                // 정상 흐름일 경우 예외를 던져서 트랜잭션 롤백 유도
+                throw new RuntimeException("Outbox 이벤트 생성 중 오류가 발생했습니다.", e);
+            }
         }
     }
 }

--- a/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
@@ -44,7 +44,10 @@ public class OrderOutboxHelper {
     // 스케줄러가 카프카 전송 성공 후 상태를 바꿀 때 사용하는 개별 독립 트랜잭션
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void markAsPublished(UUID outboxId) {
-        outboxRepository.findById(outboxId).ifPresent(OrderOutbox::markAsPublished);
+        outboxRepository.findById(outboxId).ifPresentOrElse(
+            OrderOutbox::markAsPublished,
+            () -> log.warn("[Order Outbox] 발행 성공 후 상태 변경 대상이 없습니다. outboxId={}", outboxId)
+        );
     }
 
     private void saveOutbox(

--- a/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
@@ -41,11 +41,14 @@ public class OrderOutboxHelper {
         saveOutbox(aggregateType, aggregateId, eventType, payloadObj);
     }
 
-    // 스케줄러가 카프카 전송 성공 후 상태를 바꿀 때 사용하는 개별 독립 트랜잭션
+    // 3. 스케줄러가 카프카 전송 성공 후 상태를 바꿀 때 사용하는 개별 독립 트랜잭션
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void markAsPublished(UUID outboxId) {
         outboxRepository.findById(outboxId).ifPresentOrElse(
-            OrderOutbox::markAsPublished,
+            outbox -> {
+                outbox.markAsPublished();
+                outboxRepository.save(outbox);
+            },
             () -> log.warn("[Order Outbox] 발행 성공 후 상태 변경 대상이 없습니다. outboxId={}", outboxId)
         );
     }
@@ -56,6 +59,19 @@ public class OrderOutboxHelper {
         String eventType,
         Object payloadObj
     ) {
+        if (aggregateType == null || aggregateType.isBlank()) {
+            throw new IllegalArgumentException("aggregateType은 필수입니다.");
+        }
+        if (aggregateId == null || aggregateId.isBlank()) {
+            throw new IllegalArgumentException("aggregateId는 필수입니다.");
+        }
+        if (eventType == null || eventType.isBlank()) {
+            throw new IllegalArgumentException("eventType은 필수입니다.");
+        }
+        if (payloadObj == null) {
+            throw new IllegalArgumentException("payloadObj는 필수입니다.");
+        }
+
         try {
             String payloadJson = objectMapper.writeValueAsString(payloadObj);
             OrderOutbox outbox = OrderOutbox.builder()

--- a/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
@@ -107,8 +107,25 @@ public class OrderOutboxHelper {
         if (eventType == null || eventType.isBlank()) {
             throw new IllegalArgumentException("eventType은 필수입니다.");
         }
+
+        // payload가 null일 때, 보상 트랜잭션이면 예외를 던지지 않고 에러 레코드를 남김
         if (payloadObj == null) {
-            throw new IllegalArgumentException("payloadObj는 필수입니다.");
+            if (!isCompensation) {
+                throw new IllegalArgumentException("payloadObj는 필수입니다.");
+            }
+
+            OrderOutbox errorOutbox = OrderOutbox.builder()
+                .aggregateType(aggregateType)
+                .aggregateId(aggregateId)
+                .eventType(eventType + "_PAYLOAD_MISSING_ERROR")
+                .payload("{\"error\":\"payload_missing\",\"class\":\"null\"}")
+                .build();
+
+            OrderOutbox savedErrorOutbox = outboxRepository.save(errorOutbox);
+            log.error(
+                "[CRITICAL] 보상 트랜잭션 페이로드가 null입니다. fallback 에러 이벤트를 적재했습니다. outboxId={}, aggregateId={}, eventType={}",
+                savedErrorOutbox.getId(), aggregateId, eventType);
+            return; // 밑으로 내려가지 않고 여기서 종료
         }
 
         try {

--- a/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxHelper.java
@@ -51,8 +51,8 @@ public class OrderOutboxHelper {
     public void markAsPublished(UUID outboxId) {
         outboxRepository.findById(outboxId).ifPresentOrElse(
             outbox -> {
-                // 비동기 처리 중 혹시 모를 중복 업데이트 방어
-                if (outbox.getStatus() == OutboxStatus.PUBLISHED) {
+                // 비동기 처리 중 혹시 모를 중복 업데이트 방어- INIT -> PUBLISHED 전이만 허용
+                if (outbox.getStatus() != OutboxStatus.INIT) {
                     return;
                 }
 

--- a/src/main/java/com/michelet/order/application/OrderOutboxScheduler.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxScheduler.java
@@ -6,7 +6,7 @@ import com.michelet.order.domain.model.OrderOutbox;
 import com.michelet.order.domain.model.OutboxStatus;
 import com.michelet.order.domain.repository.OrderOutboxRepository;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -50,27 +50,40 @@ public class OrderOutboxScheduler {
                 // String(JSON)을 다시 원본 Event 객체로 복원
                 Object originalEventObject = deserializePayload(event.getEventType(), event.getPayload());
 
-                // Kafka 전송 및 동기식 대기
-                // 비동기로 쏘고 바로 넘어가면, 카프카 서버가 터져서 못 받았는데도 DB는 PUBLISHED로 바뀌는 사고 발생 가능
-                //   => .get(3, TimeUnit.SECONDS)를 통해 브로커의 확실한 수신 응답(ACK)을 최대 3초간 기다림
+                // 동기 대기(.get) 제거 후 비동기 콜백 적용
                 // 복원된 객체를 보내야 JsonSerializer가 __TypeId__를 정확히 세팅함
                 kafkaTemplate.send(topic, event.getAggregateId(), originalEventObject)
-                    .get(3, TimeUnit.SECONDS);
+                    .whenComplete((result, ex) -> {
+                        if (ex == null) {
+                            try {
+                                orderOutboxHelper.markAsPublished(event.getId());
+                                log.info("[Order Outbox Scheduler] 이벤트 발행 성공! Outbox ID: {}", event.getId());
+                            } catch (ObjectOptimisticLockingFailureException oole) {
+                                log.info("[Order Outbox Scheduler] 낙관적 락 방어 (동시성 경합). Outbox ID: {}", event.getId());
+                            } catch (Exception updateEx) {
+                                log.error("[Order Outbox Scheduler] DB 상태 업데이트 실패. Outbox ID: {}", event.getId(),
+                                    updateEx);
+                            }
+                        } else {
+                            log.error("[Order Outbox Scheduler] 카프카 이벤트 발행 실패. Outbox ID: {}", event.getId(), ex);
+                            safeHandleFailure(event.getId()); // 실패 카운트 로직 실행
+                        }
+                    });
 
-                // 4. 전송에 완벽히 성공했을 때만 상태를 PUBLISHED로 변경 (JPA 더티 체킹으로 자동 UPDATE)
-                // Helper를 호출하여 새로운 독립 트랜잭션 내에서 상태 변경 수행
-                orderOutboxHelper.markAsPublished(event.getId());
-                log.info("[Order Outbox Scheduler] 이벤트 발행 성공! Outbox ID: {}", event.getId());
-
-            } catch (ObjectOptimisticLockingFailureException oole) {
-                // 다중 스케줄러 환경에서 동시 접근 시 발생. 한쪽 서버가 먼저 처리했으므로 안전하게 무시.
-                log.info("[Order Outbox Scheduler] 이미 처리된 이벤트입니다 (낙관적 락 충돌). Outbox ID: {}", event.getId());
             } catch (Exception e) {
-                // 5. 카프카가 죽어있거나 네트워크 에러가 나면 여기서 잡힘
-                // 예외를 밖으로 던지지 않고 여기서 먹어버림으로써, 다음 루프의 이벤트는 계속 처리하도록 보호함
-                // (이번에 실패한 이벤트는 상태가 여전히 INIT이므로, 5초 뒤 스케줄러가 다시 긁어와서 재시도함 (At-Least-Once 보장))
-                log.error("[Order Outbox Scheduler] 이벤트 발행 실패. 다음 주기에 재시도합니다. Outbox ID: {}", event.getId(), e);
+                log.error("[Order Outbox Scheduler] 전송 준비 중 오류 발생. Outbox ID: {}", event.getId(), e);
+                safeHandleFailure(event.getId());
             }
+        }
+    }
+
+    private void safeHandleFailure(UUID eventId) {
+        try {
+            orderOutboxHelper.handleFailure(eventId);
+        } catch (ObjectOptimisticLockingFailureException oole) {
+            log.info("[Order Outbox Scheduler] 실패 마킹 중 낙관적 락 방어. Outbox ID: {}", eventId);
+        } catch (Exception e) {
+            log.error("[Order Outbox Scheduler] 실패 상태 업데이트 중 예외 발생. Outbox ID: {}", eventId, e);
         }
     }
 
@@ -80,7 +93,10 @@ public class OrderOutboxScheduler {
             case "STOCK_RESTORE", "STOCK_RESTORED" ->
                 objectMapper.readValue(jsonPayload, StockRestoreEventPayload.class);
             // 취소나 생성 등 다른 이벤트가 추가되면 여기에 case를 늘려가면 됨
-            default -> jsonPayload;
+            default -> {
+                log.warn("등록되지 않은 알 수 없는 이벤트 타입입니다: {}", eventType);
+                throw new IllegalArgumentException("Unknown event type: " + eventType);
+            }
         };
     }
 

--- a/src/main/java/com/michelet/order/application/OrderOutboxScheduler.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxScheduler.java
@@ -9,9 +9,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderOutboxScheduler {
 
     private final JpaOrderOutboxRepository outboxRepository;
+    private final OrderOutboxHelper orderOutboxHelper; // 트랜잭션 분리를 위한 Helper 주입
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
     @Value("${order.kafka.topic.stock-restore:stock.restored}")
@@ -26,10 +27,10 @@ public class OrderOutboxScheduler {
 
     // 5초마다 주기적으로 실행
     @Scheduled(fixedDelay = 5000)
-    @Transactional
     public void processOutboxEvents() {
+        // OOM 방지 및 순서 보장을 위해 Top N 배치 조회 사용
         // 1. DB에서 INIT 상태인 이벤트 긁어오기
-        List<OrderOutbox> pendingEvents = outboxRepository.findByStatus(OutboxStatus.INIT);
+        List<OrderOutbox> pendingEvents = outboxRepository.findTop50ByStatusOrderByCreatedAtAsc(OutboxStatus.INIT);
         if (pendingEvents.isEmpty()) {
             return; // 처리할 게 없으면 조용히 턴 종료
         }
@@ -41,16 +42,20 @@ public class OrderOutboxScheduler {
                 // 2. 이벤트 타입에 따라 카프카 토픽명 결정
                 String topic = resolveTopic(event.getEventType());
 
-                // 3. Kafka 전송 및 동기식 대기
+                // Kafka 전송 및 동기식 대기
                 // 비동기로 쏘고 바로 넘어가면, 카프카 서버가 터져서 못 받았는데도 DB는 PUBLISHED로 바뀌는 사고 발생 가능
                 // => .get(3, TimeUnit.SECONDS)를 통해 브로커의 확실한 수신 응답(ACK)을 최대 3초간 기다림
                 kafkaTemplate.send(topic, event.getAggregateId(), event.getPayload())
                     .get(3, TimeUnit.SECONDS);
 
                 // 4. 전송에 완벽히 성공했을 때만 상태를 PUBLISHED로 변경 (JPA 더티 체킹으로 자동 UPDATE)
-                event.markAsPublished();
+                // Helper를 호출하여 새로운 독립 트랜잭션 내에서 상태 변경 수행
+                orderOutboxHelper.markAsPublished(event.getId());
                 log.info("[Order Outbox Scheduler] 이벤트 발행 성공! Outbox ID: {}", event.getId());
 
+            } catch (ObjectOptimisticLockingFailureException oole) {
+                // 다중 스케줄러 환경에서 동시 접근 시 발생. 한쪽 서버가 먼저 처리했으므로 안전하게 무시.
+                log.info("[Order Outbox Scheduler] 이미 처리된 이벤트입니다 (낙관적 락 충돌). Outbox ID: {}", event.getId());
             } catch (Exception e) {
                 // 5. 카프카가 죽어있거나 네트워크 에러가 나면 여기서 잡힘
                 // 예외를 밖으로 던지지 않고 여기서 먹어버림으로써, 다음 루프의 이벤트는 계속 처리하도록 보호함

--- a/src/main/java/com/michelet/order/application/OrderOutboxScheduler.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxScheduler.java
@@ -1,5 +1,7 @@
 package com.michelet.order.application;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.michelet.order.application.dto.StockRestoreEventPayload;
 import com.michelet.order.domain.model.OrderOutbox;
 import com.michelet.order.domain.model.OutboxStatus;
 import com.michelet.order.infrastructure.repository.JpaOrderOutboxRepository;
@@ -22,6 +24,9 @@ public class OrderOutboxScheduler {
     private final OrderOutboxHelper orderOutboxHelper; // 트랜잭션 분리를 위한 Helper 주입
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
+    // JSON 문자열을 객체로 복원하기 위한 매퍼 주입
+    private final ObjectMapper objectMapper;
+
     @Value("${order.kafka.topic.stock-restore:stock.restored}")
     private String stockRestoreTopic;
 
@@ -42,10 +47,14 @@ public class OrderOutboxScheduler {
                 // 2. 이벤트 타입에 따라 카프카 토픽명 결정
                 String topic = resolveTopic(event.getEventType());
 
+                // String(JSON)을 다시 원본 Event 객체로 복원
+                Object originalEventObject = deserializePayload(event.getEventType(), event.getPayload());
+
                 // Kafka 전송 및 동기식 대기
                 // 비동기로 쏘고 바로 넘어가면, 카프카 서버가 터져서 못 받았는데도 DB는 PUBLISHED로 바뀌는 사고 발생 가능
-                // => .get(3, TimeUnit.SECONDS)를 통해 브로커의 확실한 수신 응답(ACK)을 최대 3초간 기다림
-                kafkaTemplate.send(topic, event.getAggregateId(), event.getPayload())
+                //   => .get(3, TimeUnit.SECONDS)를 통해 브로커의 확실한 수신 응답(ACK)을 최대 3초간 기다림
+                // 복원된 객체를 보내야 JsonSerializer가 __TypeId__를 정확히 세팅함
+                kafkaTemplate.send(topic, event.getAggregateId(), originalEventObject)
                     .get(3, TimeUnit.SECONDS);
 
                 // 4. 전송에 완벽히 성공했을 때만 상태를 PUBLISHED로 변경 (JPA 더티 체킹으로 자동 UPDATE)
@@ -65,10 +74,20 @@ public class OrderOutboxScheduler {
         }
     }
 
+    // JSON 문자열을 원래 DTO 클래스로 변환
+    private Object deserializePayload(String eventType, String jsonPayload) throws Exception {
+        return switch (eventType) {
+            case "STOCK_RESTORE", "STOCK_RESTORED" ->
+                objectMapper.readValue(jsonPayload, StockRestoreEventPayload.class);
+            // 취소나 생성 등 다른 이벤트가 추가되면 여기에 case를 늘려가면 됨
+            default -> jsonPayload;
+        };
+    }
+
     private String resolveTopic(String eventType) {
-        if ("STOCK_RESTORE".equals(eventType)) {
-            return stockRestoreTopic; // 인벤토리 서버가 구독할 토픽명
-        }
-        return "order.unknown.event";
+        return switch (eventType) {
+            case "STOCK_RESTORE", "STOCK_RESTORED" -> stockRestoreTopic;
+            default -> "order.unknown.event";
+        };
     }
 }

--- a/src/main/java/com/michelet/order/application/OrderOutboxScheduler.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxScheduler.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.michelet.order.application.dto.StockRestoreEventPayload;
 import com.michelet.order.domain.model.OrderOutbox;
 import com.michelet.order.domain.model.OutboxStatus;
-import com.michelet.order.infrastructure.repository.JpaOrderOutboxRepository;
+import com.michelet.order.domain.repository.OrderOutboxRepository;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OrderOutboxScheduler {
 
-    private final JpaOrderOutboxRepository outboxRepository;
+    private final OrderOutboxRepository outboxRepository;
     private final OrderOutboxHelper orderOutboxHelper; // 트랜잭션 분리를 위한 Helper 주입
     private final KafkaTemplate<String, Object> kafkaTemplate;
 

--- a/src/main/java/com/michelet/order/application/OrderOutboxScheduler.java
+++ b/src/main/java/com/michelet/order/application/OrderOutboxScheduler.java
@@ -1,0 +1,69 @@
+package com.michelet.order.application;
+
+import com.michelet.order.domain.model.OrderOutbox;
+import com.michelet.order.domain.model.OutboxStatus;
+import com.michelet.order.infrastructure.repository.JpaOrderOutboxRepository;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderOutboxScheduler {
+
+    private final JpaOrderOutboxRepository outboxRepository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${order.kafka.topic.stock-restore:stock.restored}")
+    private String stockRestoreTopic;
+
+    // 5초마다 주기적으로 실행
+    @Scheduled(fixedDelay = 5000)
+    @Transactional
+    public void processOutboxEvents() {
+        // 1. DB에서 INIT 상태인 이벤트 긁어오기
+        List<OrderOutbox> pendingEvents = outboxRepository.findByStatus(OutboxStatus.INIT);
+        if (pendingEvents.isEmpty()) {
+            return; // 처리할 게 없으면 조용히 턴 종료
+        }
+
+        log.info("[Order Outbox Scheduler] {}개의 미발행 이벤트를 찾아 Kafka 전송을 시도합니다.", pendingEvents.size());
+
+        for (OrderOutbox event : pendingEvents) {
+            try {
+                // 2. 이벤트 타입에 따라 카프카 토픽명 결정
+                String topic = resolveTopic(event.getEventType());
+
+                // 3. Kafka 전송 및 동기식 대기
+                // 비동기로 쏘고 바로 넘어가면, 카프카 서버가 터져서 못 받았는데도 DB는 PUBLISHED로 바뀌는 사고 발생 가능
+                // => .get(3, TimeUnit.SECONDS)를 통해 브로커의 확실한 수신 응답(ACK)을 최대 3초간 기다림
+                kafkaTemplate.send(topic, event.getAggregateId(), event.getPayload())
+                    .get(3, TimeUnit.SECONDS);
+
+                // 4. 전송에 완벽히 성공했을 때만 상태를 PUBLISHED로 변경 (JPA 더티 체킹으로 자동 UPDATE)
+                event.markAsPublished();
+                log.info("[Order Outbox Scheduler] 이벤트 발행 성공! Outbox ID: {}", event.getId());
+
+            } catch (Exception e) {
+                // 5. 카프카가 죽어있거나 네트워크 에러가 나면 여기서 잡힘
+                // 예외를 밖으로 던지지 않고 여기서 먹어버림으로써, 다음 루프의 이벤트는 계속 처리하도록 보호함
+                // (이번에 실패한 이벤트는 상태가 여전히 INIT이므로, 5초 뒤 스케줄러가 다시 긁어와서 재시도함 (At-Least-Once 보장))
+                log.error("[Order Outbox Scheduler] 이벤트 발행 실패. 다음 주기에 재시도합니다. Outbox ID: {}", event.getId(), e);
+            }
+        }
+    }
+
+    private String resolveTopic(String eventType) {
+        if ("STOCK_RESTORE".equals(eventType)) {
+            return stockRestoreTopic; // 인벤토리 서버가 구독할 토픽명
+        }
+        return "order.unknown.event";
+    }
+}

--- a/src/main/java/com/michelet/order/application/dto/StockRestoreEventPayload.java
+++ b/src/main/java/com/michelet/order/application/dto/StockRestoreEventPayload.java
@@ -1,5 +1,6 @@
 package com.michelet.order.application.dto;
 
+import java.util.Objects;
 import java.util.UUID;
 
 // Outbox의 payload(json)로 직렬화될 객체
@@ -8,4 +9,12 @@ public record StockRestoreEventPayload(
     UUID optionId,
     Integer quantity
 ) {
+    public StockRestoreEventPayload {
+        Objects.requireNonNull(eventId, "eventId는 null일 수 없습니다");
+        Objects.requireNonNull(optionId, "optionId는 null일 수 없습니다");
+
+        if (quantity == null || quantity <= 0) {
+            throw new IllegalArgumentException("quantity는 1 이상의 양수여야 합니다.");
+        }
+    }
 }

--- a/src/main/java/com/michelet/order/application/dto/StockRestoreEventPayload.java
+++ b/src/main/java/com/michelet/order/application/dto/StockRestoreEventPayload.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 // Outbox의 payload(json)로 직렬화될 객체
 public record StockRestoreEventPayload(
+    UUID eventId, // Consumer가 중복을 판별할 고유 식별자 (멱등성 키)
     UUID optionId,
     Integer quantity
 ) {

--- a/src/main/java/com/michelet/order/application/dto/StockRestoreEventPayload.java
+++ b/src/main/java/com/michelet/order/application/dto/StockRestoreEventPayload.java
@@ -1,0 +1,10 @@
+package com.michelet.order.application.dto;
+
+import java.util.UUID;
+
+// Outbox의 payload(json)로 직렬화될 객체
+public record StockRestoreEventPayload(
+    UUID optionId,
+    Integer quantity
+) {
+}

--- a/src/main/java/com/michelet/order/domain/model/OrderOutbox.java
+++ b/src/main/java/com/michelet/order/domain/model/OrderOutbox.java
@@ -48,6 +48,9 @@ public class OrderOutbox extends BaseEntity {
     @Version
     private Long version;
 
+    @Column(nullable = false)
+    private Integer retryCount = 0;
+
     @Builder
     private OrderOutbox(
         String aggregateType,
@@ -60,9 +63,22 @@ public class OrderOutbox extends BaseEntity {
         this.eventType = eventType;
         this.payload = payload;
         this.status = OutboxStatus.INIT; // 생성 시 기본값은 INIT
+        this.retryCount = 0;
     }
 
     public void markAsPublished() {
         this.status = OutboxStatus.PUBLISHED;
+    }
+
+    // 영구 실패 상태 전이 로직
+    public void markAsFailed() {
+        this.status = OutboxStatus.FAILED;
+    }
+
+    public void incrementRetryCount() {
+        if (this.retryCount == null) {
+            this.retryCount = 0;
+        }
+        this.retryCount++;
     }
 }

--- a/src/main/java/com/michelet/order/domain/model/OrderOutbox.java
+++ b/src/main/java/com/michelet/order/domain/model/OrderOutbox.java
@@ -57,4 +57,8 @@ public class OrderOutbox extends BaseEntity {
         this.payload = payload;
         this.status = OutboxStatus.INIT; // 생성 시 기본값은 INIT
     }
+
+    public void markAsPublished() {
+        this.status = OutboxStatus.PUBLISHED;
+    }
 }

--- a/src/main/java/com/michelet/order/domain/model/OrderOutbox.java
+++ b/src/main/java/com/michelet/order/domain/model/OrderOutbox.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -43,6 +44,9 @@ public class OrderOutbox extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private OutboxStatus status;
+
+    @Version
+    private Long version;
 
     @Builder
     private OrderOutbox(

--- a/src/main/java/com/michelet/order/domain/model/OrderOutbox.java
+++ b/src/main/java/com/michelet/order/domain/model/OrderOutbox.java
@@ -1,0 +1,60 @@
+package com.michelet.order.domain.model;
+
+import com.michelet.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "p_order_outbox")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderOutbox extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, length = 50)
+    private String aggregateType; // 예: "ORDER", "INVENTORY"
+
+    @Column(nullable = false, length = 50)
+    private String aggregateId; // 주문 ID 또는 예약 ID
+
+    @Column(nullable = false, length = 50)
+    private String eventType; // 예: "STOCK_RESTORE"
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private String payload; // Kafka로 던질 JSON 데이터
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OutboxStatus status;
+
+    @Builder
+    private OrderOutbox(
+        String aggregateType,
+        String aggregateId,
+        String eventType,
+        String payload
+    ) {
+        this.aggregateType = aggregateType;
+        this.aggregateId = aggregateId;
+        this.eventType = eventType;
+        this.payload = payload;
+        this.status = OutboxStatus.INIT; // 생성 시 기본값은 INIT
+    }
+}

--- a/src/main/java/com/michelet/order/domain/model/OutboxStatus.java
+++ b/src/main/java/com/michelet/order/domain/model/OutboxStatus.java
@@ -1,0 +1,6 @@
+package com.michelet.order.domain.model;
+
+public enum OutboxStatus {
+    INIT,      // 초기 생성 상태 (발행 대기)
+    PUBLISHED  // Kafka 발행 완료 상태
+}

--- a/src/main/java/com/michelet/order/domain/model/OutboxStatus.java
+++ b/src/main/java/com/michelet/order/domain/model/OutboxStatus.java
@@ -1,6 +1,7 @@
 package com.michelet.order.domain.model;
 
 public enum OutboxStatus {
-    INIT,      // 초기 생성 상태 (발행 대기)
-    PUBLISHED  // Kafka 발행 완료 상태
+    INIT,       // 초기 생성 상태 (발행 대기)
+    PUBLISHED,  // Kafka 발행 완료 상태
+    FAILED      // 최대 재시도 초과로 영구 실패 (격리)
 }

--- a/src/main/java/com/michelet/order/domain/repository/OrderOutboxRepository.java
+++ b/src/main/java/com/michelet/order/domain/repository/OrderOutboxRepository.java
@@ -1,7 +1,15 @@
 package com.michelet.order.domain.repository;
 
 import com.michelet.order.domain.model.OrderOutbox;
+import com.michelet.order.domain.model.OutboxStatus;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface OrderOutboxRepository {
     OrderOutbox save(OrderOutbox outbox);
+
+    Optional<OrderOutbox> findById(UUID id);
+    
+    List<OrderOutbox> findTop50ByStatusOrderByCreatedAtAsc(OutboxStatus status);
 }

--- a/src/main/java/com/michelet/order/domain/repository/OrderOutboxRepository.java
+++ b/src/main/java/com/michelet/order/domain/repository/OrderOutboxRepository.java
@@ -1,0 +1,7 @@
+package com.michelet.order.domain.repository;
+
+import com.michelet.order.domain.model.OrderOutbox;
+
+public interface OrderOutboxRepository {
+    OrderOutbox save(OrderOutbox outbox);
+}

--- a/src/main/java/com/michelet/order/infrastructure/repository/JpaOrderOutboxRepository.java
+++ b/src/main/java/com/michelet/order/infrastructure/repository/JpaOrderOutboxRepository.java
@@ -1,0 +1,8 @@
+package com.michelet.order.infrastructure.repository;
+
+import com.michelet.order.domain.model.OrderOutbox;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaOrderOutboxRepository extends JpaRepository<OrderOutbox, UUID> {
+}

--- a/src/main/java/com/michelet/order/infrastructure/repository/JpaOrderOutboxRepository.java
+++ b/src/main/java/com/michelet/order/infrastructure/repository/JpaOrderOutboxRepository.java
@@ -1,8 +1,12 @@
 package com.michelet.order.infrastructure.repository;
 
 import com.michelet.order.domain.model.OrderOutbox;
+import com.michelet.order.domain.model.OutboxStatus;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaOrderOutboxRepository extends JpaRepository<OrderOutbox, UUID> {
+    // 발행 대기(INIT) 상태인 이벤트만 긁어오기
+    List<OrderOutbox> findByStatus(OutboxStatus status);
 }

--- a/src/main/java/com/michelet/order/infrastructure/repository/JpaOrderOutboxRepository.java
+++ b/src/main/java/com/michelet/order/infrastructure/repository/JpaOrderOutboxRepository.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaOrderOutboxRepository extends JpaRepository<OrderOutbox, UUID> {
-    // 발행 대기(INIT) 상태인 이벤트만 긁어오기
-    List<OrderOutbox> findByStatus(OutboxStatus status);
+
+    // OOM 방지 및 순서 보장을 위해 Top N개 생성순 조회로 변경
+    List<OrderOutbox> findTop50ByStatusOrderByCreatedAtAsc(OutboxStatus status);
 }

--- a/src/main/java/com/michelet/order/infrastructure/repository/OrderOutboxRepositoryImpl.java
+++ b/src/main/java/com/michelet/order/infrastructure/repository/OrderOutboxRepositoryImpl.java
@@ -1,7 +1,11 @@
 package com.michelet.order.infrastructure.repository;
 
 import com.michelet.order.domain.model.OrderOutbox;
+import com.michelet.order.domain.model.OutboxStatus;
 import com.michelet.order.domain.repository.OrderOutboxRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +18,15 @@ public class OrderOutboxRepositoryImpl implements OrderOutboxRepository {
     @Override
     public OrderOutbox save(OrderOutbox outbox) {
         return jpaRepository.save(outbox);
+    }
+
+    @Override
+    public Optional<OrderOutbox> findById(UUID id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<OrderOutbox> findTop50ByStatusOrderByCreatedAtAsc(OutboxStatus status) {
+        return jpaRepository.findTop50ByStatusOrderByCreatedAtAsc(status);
     }
 }

--- a/src/main/java/com/michelet/order/infrastructure/repository/OrderOutboxRepositoryImpl.java
+++ b/src/main/java/com/michelet/order/infrastructure/repository/OrderOutboxRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.michelet.order.infrastructure.repository;
+
+import com.michelet.order.domain.model.OrderOutbox;
+import com.michelet.order.domain.repository.OrderOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderOutboxRepositoryImpl implements OrderOutboxRepository {
+
+    private final JpaOrderOutboxRepository jpaRepository;
+
+    @Override
+    public OrderOutbox save(OrderOutbox outbox) {
+        return jpaRepository.save(outbox);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,11 @@ spring:
 server:
     port: 19700
 
+order:
+    kafka:
+        topic:
+            stock-restore: "stock.restored"
+
 internal:
     auth:
         secret: ${INTERNAL_AUTH_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,8 @@ order:
     kafka:
         topic:
             stock-restore: "stock.restored"
+    outbox:
+        max-retries: 3 # 최대 재시도 횟수 설정
 
 internal:
     auth:

--- a/src/test/java/com/michelet/order/application/OrderCommandServiceTest.java
+++ b/src/test/java/com/michelet/order/application/OrderCommandServiceTest.java
@@ -4,15 +4,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.michelet.common.response.ApiResponse;
 import com.michelet.order.application.dto.CreateOrderCommand;
 import com.michelet.order.application.dto.OrderResult;
+import com.michelet.order.application.dto.StockRestoreEventPayload;
 import com.michelet.order.application.port.out.ReservationValidationPort;
 import com.michelet.order.domain.model.Order;
+import com.michelet.order.domain.model.OrderItem;
 import com.michelet.order.domain.model.OrderStatus;
+import com.michelet.order.domain.model.ReceivingMethod;
 import com.michelet.order.domain.repository.OrderRepository;
 import com.michelet.order.infrastructure.client.CatalogClient;
 import com.michelet.order.infrastructure.client.InventoryClient;
@@ -20,6 +26,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +37,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
@@ -42,6 +50,10 @@ class OrderCommandServiceTest {
     private InventoryClient inventoryClient;
     @Mock
     private CatalogClient catalogClient;
+
+    // Outbox 로직 테스트를 위한 Mock 객체 추가
+    @Mock
+    private OrderOutboxHelper orderOutboxHelper;
 
     @InjectMocks
     private OrderCommandService orderCommandService;
@@ -73,9 +85,9 @@ class OrderCommandServiceTest {
         );
 
         given(reservationValidationPort.validateAndGetDate(
-            command.reservationId(),
-            command.userId(),
-            command.restaurantId()
+            any(),
+            any(),
+            any()
         )).willReturn(LocalDate.now());
 
         given(catalogClient.validateOption(optionId1))
@@ -94,21 +106,120 @@ class OrderCommandServiceTest {
         verify(orderRepository).save(orderCaptor.capture());
         Order savedOrder = orderCaptor.getValue();
 
-        // 55000 * 2 + 12000 * 3 = 146000
+        // 1. 총액 검증 (55000 * 2 + 12000 * 3 = 146000)
         assertThat(savedOrder.getTotalAmount()).isEqualByComparingTo(new BigDecimal("146000"));
+        // 2. 상태 검증
         assertThat(savedOrder.getStatus()).isEqualTo(OrderStatus.OCCUPIED);
+        // 3. 아이템 개수 검증
         assertThat(savedOrder.getOrderItems()).hasSize(2);
-
-        // 3. 자동 생성된 주문 이름 검증
+        // 4. 자동 생성된 주문 이름 검증
         assertThat(savedOrder.getOrderName()).isEqualTo("티본 스테이크 외 1건");
 
-        // 4. 카탈로그에서 가져온 이름이 정상적으로 스냅샷에 저장되었는지 검증
+        // 5. 카탈로그에서 가져온 이름이 정상적으로 스냅샷에 저장되었는지 검증
         assertThat(savedOrder.getOrderItems())
             .extracting("productName", "quantity")
             .containsExactly(
                 tuple("티본 스테이크", 2),
                 tuple("하우스 와인", 3)
             );
+    }
+
+    @Test
+    @DisplayName("실패: 두 번째 상품 재고 선점 중 에러 발생 시, 첫 번째 상품에 대한 복구 이벤트가 Outbox에 저장되어야 한다")
+    void createOrder_Fail_ShouldSaveOutboxCompensation() {
+        // given
+        UUID optionId1 = UUID.randomUUID();
+        UUID optionId2 = UUID.randomUUID();
+        UUID reservationId = UUID.randomUUID();
+
+        CreateOrderCommand command = new CreateOrderCommand(
+            UUID.randomUUID(), reservationId, UUID.randomUUID(),
+            null, "PICKUP", LocalDateTime.now().plusHours(2),
+            List.of(
+                new CreateOrderCommand.OrderItemCommand(optionId1, 2), // 1번은 성공 가정
+                new CreateOrderCommand.OrderItemCommand(optionId2, 3)  // 2번에서 에러 발생 예정
+            )
+        );
+
+        given(reservationValidationPort.validateAndGetDate(
+            any(),
+            any(),
+            any()
+        )).willReturn(LocalDate.now());
+
+        given(catalogClient.validateOption(optionId1))
+            .willReturn(
+                ApiResponse.ok(new CatalogClient.OptionValidationResponse(
+                    optionId1,
+                    "상품1",
+                    new BigDecimal("1000")
+                )));
+        given(catalogClient.validateOption(optionId2))
+            .willReturn(
+                ApiResponse.ok(new CatalogClient.OptionValidationResponse(
+                    optionId2,
+                    "상품2",
+                    new BigDecimal("2000")
+                )));
+
+        // 첫 번째 상품(optionId1)은 정상적으로 통과되도록 Mock 설정 추가 (Strict Stubbing 해결)
+        given(inventoryClient.reserveStock(new InventoryClient.ReserveStockRequest(optionId1, 2)))
+            .willReturn(ApiResponse.ok(null));
+
+        // 두 번째 아이템 예약 시 강제로 에러를 던지도록 설정
+        doThrow(new RuntimeException("인벤토리 통신 에러"))
+            .when(inventoryClient).reserveStock(new InventoryClient.ReserveStockRequest(optionId2, 3));
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.createOrder(command))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("인벤토리 통신 에러");
+
+        // 첫 번째 상품(성공했던 것)을 다시 돌려놓기 위해 appendCompensation이 호출되었는지 검증
+        verify(orderOutboxHelper, times(1)).appendCompensation(
+            eq("ORDER"),
+            eq(reservationId.toString()),
+            eq("STOCK_RESTORE"),
+            any(StockRestoreEventPayload.class)
+        );
+    }
+
+    @Test
+    @DisplayName("성공: 주문 취소 시 해당 주문의 모든 아이템에 대해 재고 복구 이벤트가 Outbox에 저장되어야 한다")
+    void cancelOrder_Success_ShouldSaveOutbox() {
+        // given
+        UUID orderId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UUID optionId = UUID.randomUUID();
+
+        OrderItem item = OrderItem.create(optionId, "테스트상품", new BigDecimal("1000"), 2);
+        Order order = Order.create(
+            userId,
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "테스트 주문",
+            LocalDate.now().plusDays(1),
+            ReceivingMethod.PICKUP,
+            LocalDateTime.now().plusHours(2),
+            List.of(item)
+        );
+
+        // 단위 테스트에서는 DB에 안 가므로 ID가 null임 - 리플렉션으로 가짜 ID 주입 (NPE 해결)
+        ReflectionTestUtils.setField(order, "id", orderId);
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        // when
+        orderCommandService.cancelOrder(orderId, userId);
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
+        verify(orderOutboxHelper, times(1)).append(
+            eq("ORDER"),
+            eq(orderId.toString()),
+            eq("STOCK_RESTORE"),
+            any(StockRestoreEventPayload.class)
+        );
     }
 
     @Test


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 주문에 Outbox, 스케줄러를 연결해서 재고 복구에 대한 모든 로직을 수정

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #11 , Close #12   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="1045" height="180" alt="스크린샷 2026-05-12 오후 7 53 26" src="https://github.com/user-attachments/assets/179f381f-f05c-48c1-a11f-54b3f314a2bc" />
<img width="1037" height="246" alt="스크린샷 2026-05-12 오후 7 53 37" src="https://github.com/user-attachments/assets/9d959ff7-fa2b-458b-b208-d61970dbdf4e" />
<img width="1086" height="165" alt="스크린샷 2026-05-12 오후 8 10 57" src="https://github.com/user-attachments/assets/d061f5fa-4496-4876-ab02-14fef0b426fb" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 주문 아웃박스 레코드 생성·관리 및 주기적 스케줄러로 이벤트를 비동기 발행합니다.

* **개선**
  * 주문 생성·취소의 재고 복원 흐름이 아웃박스 기반 보상(비동기)으로 전환되어 장애 격리와 복구 신뢰성이 향상되었습니다.
  * 재시도 카운트·실패 상태 관리와 페이로드 검증으로 안정성·관측성이 강화되었습니다.
  * 스케줄러가 발행 결과에 따라 상태를 갱신하고 실패를 처리합니다.

* **설정**
  * Kafka 연동 및 재고 복원용 토픽 매핑이 추가되었습니다.

* **테스트**
  * 아웃박스 보상·취소·스케줄러와 격리 시나리오를 검증하는 테스트·시나리오가 추가/확장되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/order-service/pull/23)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->