### PR TITLE
Refactor/30 - 주문 생성 직후 취소 상황에서 발생하던 순서 역전 현상 해결

### DIFF
--- a/api-test/order.http
+++ b/api-test/order.http
@@ -979,3 +979,46 @@ Authorization: Bearer {{ord_userToken}}
         client.log("3단계 완료: 주문 상태가 정상적으로 CANCELED로 처리됨.");
     });
 %}
+
+### 01. [주문 생성] 동일한 optionId의 상품을 장바구니에 나누어 담아 중복 요청 유도
+POST {{gatewayUrl}}/api/v1/orders
+Authorization: Bearer {{ord_userToken}}
+Content-Type: application/json
+
+{
+    "restaurantId": "{{dummy_restaurant_id}}",
+    "reservationId": "{{$random.uuid}}",
+    "orderName": "단일 토픽 순서 보장 테스트 주문",
+    "receivingMethod": "PICKUP",
+    "expiredAt": "2026-12-31T18:00:00",
+    "items": [
+        {
+            "optionId": "{{ord_option_id_2_1_kafka}}",
+            "quantity": 2
+        },
+        {
+             "optionId": "{{ord_option_id_2_1_kafka}}",
+             "quantity": 3
+        }
+    ]
+}
+
+> {%
+    client.test("주문 생성 성공 및 데이터 추출", function () {
+        client.assert(response.status === 201, "주문 등록에 실패했습니다.");
+        client.global.set("order_in_order_id", response.body.data.orderId);
+        client.log("생성된 가짜 주문 고유 ID: " + response.body.data.orderId);
+    });
+%}
+
+### 02. [주문 취소] 생성된 주문을 취소하여 집계 스케줄러 트리거 구동 - 조금 시간 지나서 확정된 뒤에 실행
+PATCH {{gatewayUrl}}/api/v1/orders/{{order_in_order_id}}/cancel
+Authorization: Bearer {{ord_userToken}}
+
+> {%
+    client.test("주문 취소 및 Outbox 원자성 적재 성공 확인", function () {
+        client.assert(response.status === 200, "주문 취소 요청에 실패했습니다.");
+        client.log("주문 취소 처리 성공! 이제 오더 서비스 서버 콘솔에 '수량 5(2+3)'로 합산된 로그가 1줄만 출력되었는지 검증 필요.");
+        client.log("예: 주문 변경/취소에 따른 재고 복구 Outbox 저장 완료: optionId= ~, quantity=5");
+    });
+%}

--- a/api-test/order.http
+++ b/api-test/order.http
@@ -887,7 +887,7 @@ Authorization: Bearer {{ord_userToken}}
 
 
 ### 1. 정상 주문 생성 (테스트용 상품 1개) - [엣지 케이스 시뮬레이션] 결정적 UUID(Deterministic UUID) 멱등성 검증
-POST http://localhost:19000/api/v1/orders
+POST {{gatewayUrl}}/api/v1/orders
 Authorization: Bearer {{ord_userToken}}
 Content-Type: application/json
 
@@ -915,7 +915,7 @@ Content-Type: application/json
 
 ### 2. 유저의 기습 취소 요청 (이 시점에 첫 번째 STOCK_RESTORE 발행) - [엣지 케이스 시뮬레이션] 결정적 UUID(Deterministic UUID) 멱등성 검증
 # 이 요청 직후, 인벤토리에서 뒤늦게 승인(ORDER_APPROVED) 메시지가 도착하면 두 번째 STOCK_RESTORE가 발행됨
-PATCH http://localhost:19000/api/v1/orders/{{idempotency_test_order_id}}/cancel
+PATCH {{gatewayUrl}}/api/v1/orders/{{idempotency_test_order_id}}/cancel
 Authorization: Bearer {{ord_userToken}}
 Content-Type: application/json
 
@@ -926,6 +926,17 @@ Content-Type: application/json
     });
 %}
 
+### 3. [최종 검증] 멱등성 테스트 주문 상태 확인 (CANCELED)
+GET {{gatewayUrl}}/api/v1/orders/{{idempotency_test_order_id}}
+Accept: application/json
+Authorization: Bearer {{ord_userToken}}
+
+> {%
+    client.test("멱등성 테스트 주문 상태 CANCELED 확인", function () {
+        client.assert(response.status === 200, "조회 실패");
+        client.assert(response.body.data.status === "CANCELED", "주문이 CANCELED 상태가 아닙니다.");
+    });
+%}
 
 ### 1. [순서 보장 테스트] 주문 생성 (동시에 인벤토리 차감 커맨드 발행) - 단일 토픽 & 파티션 키 라우팅 (순서 역전 및 재고 누수 해결)
 POST {{gatewayUrl}}/api/v1/orders

--- a/api-test/order.http
+++ b/api-test/order.http
@@ -809,7 +809,7 @@ Content-Type: application/json
     });
 %}
 
-### 0. 오더 테스트용 상품 2 등록 (Owner) - saveCompensationOutbox 삭제 후 테스트용
+### 0. 카프카 - 오더 테스트용 상품 2 등록 (Owner) - saveCompensationOutbox 삭제 후 테스트용
 POST {{gatewayUrl}}/api/v1/products
 Content-Type: application/json
 Authorization: Bearer {{ord_ownerToken}}
@@ -882,5 +882,100 @@ Authorization: Bearer {{ord_userToken}}
         client.assert(response.status === 200, "조회 실패");
         client.assert(response.body.data.status === "CANCELED", "주문이 CANCELED 상태가 아님 - 아직 처리 중이거나 Saga 롤백에 실패.");
         client.log("2단계 성공! 인벤토리가 재고 부족을 감지하여 ORDER_REJECTED를 발행했고, 오더 서비스가 이를 받아 CANCELED로 롤백.");
+    });
+%}
+
+
+### 1. 정상 주문 생성 (테스트용 상품 1개) - [엣지 케이스 시뮬레이션] 결정적 UUID(Deterministic UUID) 멱등성 검증
+POST http://localhost:19000/api/v1/orders
+Authorization: Bearer {{ord_userToken}}
+Content-Type: application/json
+
+{
+    "restaurantId": "{{dummy_restaurant_id}}",
+    "reservationId": "{{$random.uuid}}",
+    "orderName": "결정적 UUID 멱등성 테스트",
+    "receivingMethod": "PICKUP",
+    "expiredAt": "2026-12-31T18:00:00",
+    "items": [
+        {
+            "optionId": "{{ord_option_id_2_1_kafka}}",
+            "quantity": 1
+        }
+    ]
+}
+
+> {%
+    client.test("정상 주문 생성", function () {
+        client.assert(response.status === 201, "201 응답 실패");
+        client.global.set("idempotency_test_order_id", response.body.data.orderId);
+        client.log("주문 생성 완료. Order ID: " + response.body.data.orderId);
+    });
+%}
+
+### 2. 유저의 기습 취소 요청 (이 시점에 첫 번째 STOCK_RESTORE 발행) - [엣지 케이스 시뮬레이션] 결정적 UUID(Deterministic UUID) 멱등성 검증
+# 이 요청 직후, 인벤토리에서 뒤늦게 승인(ORDER_APPROVED) 메시지가 도착하면 두 번째 STOCK_RESTORE가 발행됨
+PATCH http://localhost:19000/api/v1/orders/{{idempotency_test_order_id}}/cancel
+Authorization: Bearer {{ord_userToken}}
+Content-Type: application/json
+
+> {%
+    client.test("기습 취소 완료", function () {
+        client.assert(response.status === 200, "취소 실패");
+        client.log("취소 완료! 이제 콘솔 로그와 DB에서 결정적 UUID가 잘 적용되었는지 확인 필요.");
+    });
+%}
+
+
+### 1. [순서 보장 테스트] 주문 생성 (동시에 인벤토리 차감 커맨드 발행) - 단일 토픽 & 파티션 키 라우팅 (순서 역전 및 재고 누수 해결)
+POST {{gatewayUrl}}/api/v1/orders
+Authorization: Bearer {{ord_userToken}}
+Content-Type: application/json
+
+{
+    "restaurantId": "{{dummy_restaurant_id}}",
+    "reservationId": "{{$random.uuid}}",
+    "orderName": "단일 토픽 순서 보장 테스트 주문",
+    "receivingMethod": "PICKUP",
+    "expiredAt": "2026-12-31T18:00:00",
+    "items": [
+        {
+            "optionId": "{{ord_option_id_2_1_kafka}}",
+            "quantity": 1
+        }
+    ]
+}
+
+> {%
+    client.test("정상 주문 PENDING 상태로 큐 적재 성공", function () {
+        client.assert(response.status === 201, "201 응답 실패! 설정 다시 확인 필요.");
+        client.global.set("order_in_order_id", response.body.data.orderId);
+        client.log("1단계 완료: 주문 ID = " + response.body.data.orderId);
+    });
+%}
+
+### 2. [기습 취소 실행] 생성 직후 즉시 취소 요청 (복구 커맨드를 동일 토픽+동일 키로 발행) - 단일 토픽 & 파티션 키 라우팅 (순서 역전 및 재고 누수 해결)
+# 1번 요청을 보내자마자 최대한 빠르게 실행해야 함 (동시성 경합 유도)
+PATCH {{gatewayUrl}}/api/v1/orders/{{order_in_order_id}}/cancel
+Authorization: Bearer {{ord_userToken}}
+Content-Type: application/json
+
+> {%
+    client.test("유저 기습 취소 API 호출 성공", function () {
+        client.assert(response.status === 200, "취소 API 호출 실패");
+        client.log("2단계 완료: 이제 인벤토리 콘솔 로그와 DB p_stocks 테이블을 검증해야 함.");
+    });
+%}
+
+### 3. [최종 검증] 오더 서비스 측 주문 상태가 CANCELED로 완료되었는지 확인 - 단일 토픽 & 파티션 키 라우팅 (순서 역전 및 재고 누수 해결)
+GET {{gatewayUrl}}/api/v1/orders/{{order_in_order_id}}
+Accept: application/json
+Authorization: Bearer {{ord_userToken}}
+
+> {%
+    client.test("최종 주문 상태 CANCELED 확인", function () {
+        client.assert(response.status === 200, "조회 실패");
+        client.assert(response.body.data.status === "CANCELED", "주문이 아직 PENDING이거나 롤백되지 않았음.");
+        client.log("3단계 완료: 주문 상태가 정상적으로 CANCELED로 처리됨.");
     });
 %}

--- a/src/main/java/com/michelet/order/application/OrderCommandService.java
+++ b/src/main/java/com/michelet/order/application/OrderCommandService.java
@@ -11,10 +11,13 @@ import com.michelet.order.domain.model.OrderStatus;
 import com.michelet.order.domain.model.ReceivingMethod;
 import com.michelet.order.domain.repository.OrderRepository;
 import com.michelet.order.infrastructure.client.CatalogClient;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -139,22 +142,9 @@ public class OrderCommandService {
                 // - 확실한 재고 원복을 위해 방어적으로 STOCK_RESTORE를 한 번 더 재발행함
                 // -> 이로 인해 발생할 수 있는 2번의 복구 이벤트는 인벤토리 서비스의 멱등성 처리로 안전하게 무시됨!
                 log.warn("[Order Saga Edge-Case] 이미 유저가 취소한 주문에 대해 승인이 도착했습니다. 인벤토리 롤백 이벤트를 발행합니다: {}", reservationId);
-                for (OrderItem item : order.getOrderItems()) {
-                    // 동일한 비즈니스 행위에 대해 결정적(Deterministic) UUID 기반의 고유 식별자 발급
-                    String uniqueKey = "RESTORE_" + order.getId().toString() + "_" + item.getOptionId().toString();
-                    UUID deterministicEventId = UUID.nameUUIDFromBytes(uniqueKey.getBytes());
 
-                    orderOutboxHelper.append(
-                        "ORDER",
-                        order.getReservationId().toString(), //ORDER_CREATED와 똑같은 카프카 파티션에 들어가게 만들기 위함
-                        "STOCK_RESTORE",
-                        new StockRestoreEventPayload(
-                            deterministicEventId,
-                            item.getOptionId(),
-                            item.getQuantity()
-                        )
-                    );
-                }
+                // 수량 합산 및 Outbox 기록 공통 메서드 호출
+                this.appendStockRestoreOutbox(order);
             } else {
                 log.info("[Idempotency] 이미 처리된 주문입니다. (현재 상태: {})", order.getStatus());
             }
@@ -194,22 +184,40 @@ public class OrderCommandService {
         // 방문 예정일 이전인지 확인하고 상태 변경 (현재 시점 전달)
         order.cancel(LocalDate.now());
 
-        for (OrderItem item : order.getOrderItems()) {
+        // 수량 합산 및 Outbox 기록 공통 메서드 호출
+        this.appendStockRestoreOutbox(order);
+    }
+
+    /**
+     * 동일 optionId 상품에 대한 수량을 미리 합산한 뒤 결정적 고유 식별자로 Outbox 적재
+     */
+    private void appendStockRestoreOutbox(Order order) {
+        Map<UUID, Integer> restoreByOption = order.getOrderItems().stream()
+            .collect(Collectors.groupingBy(
+                OrderItem::getOptionId,
+                Collectors.summingInt(OrderItem::getQuantity)
+            ));
+
+        for (Map.Entry<UUID, Integer> entry : restoreByOption.entrySet()) {
+            UUID optionId = entry.getKey();
+            int quantity = entry.getValue();
+
             // 동일한 비즈니스 행위에 대해 결정적(Deterministic) UUID 기반의 고유 식별자 발급
-            String uniqueKey = "RESTORE_" + order.getId().toString() + "_" + item.getOptionId().toString();
-            UUID deterministicEventId = UUID.nameUUIDFromBytes(uniqueKey.getBytes());
+            String uniqueKey = "RESTORE_" + order.getId().toString() + "_" + optionId.toString();
+            UUID deterministicEventId = UUID.nameUUIDFromBytes(uniqueKey.getBytes(StandardCharsets.UTF_8));
 
             orderOutboxHelper.append(
                 "ORDER",
-                order.getReservationId().toString(), //ORDER_CREATED와 똑같은 카프카 파티션에 들어가게 만들기 위함
+                order.getReservationId().toString(), // ORDER_CREATED와 똑같은 카프카 파티션에 들어가게 만들기 위함
                 "STOCK_RESTORE",
                 new StockRestoreEventPayload(
                     deterministicEventId,
-                    item.getOptionId(),
-                    item.getQuantity()
+                    optionId,
+                    quantity
                 )
             );
-            log.info("주문 취소에 따른 재고 복구 Outbox 저장 완료: optionId={}, quantity={}", item.getOptionId(), item.getQuantity());
+            log.info("주문 변경/취소에 따른 재고 복구 Outbox 저장 완료: optionId={}, quantity={}, eventId={}",
+                optionId, quantity, deterministicEventId);
         }
     }
 

--- a/src/main/java/com/michelet/order/application/OrderCommandService.java
+++ b/src/main/java/com/michelet/order/application/OrderCommandService.java
@@ -117,7 +117,11 @@ public class OrderCommandService {
         // 3. PENDING 상태로 주문 저장 및 아웃박스 동시 기록
         Order savedOrder = orderStore.saveOrderAndOutbox(order, payload);
 
-        return new OrderResult(savedOrder.getId(), savedOrder.getStatus().name(), savedOrder.getOrderName());
+        return new OrderResult(
+            savedOrder.getId(),
+            savedOrder.getStatus().name(),
+            savedOrder.getOrderName()
+        );
     }
 
     // 인벤토리에서 승인 완료 메시지가 오면 상태 변경
@@ -136,9 +140,19 @@ public class OrderCommandService {
                 // -> 이로 인해 발생할 수 있는 2번의 복구 이벤트는 인벤토리 서비스의 멱등성 처리로 안전하게 무시됨!
                 log.warn("[Order Saga Edge-Case] 이미 유저가 취소한 주문에 대해 승인이 도착했습니다. 인벤토리 롤백 이벤트를 발행합니다: {}", reservationId);
                 for (OrderItem item : order.getOrderItems()) {
+                    // 동일한 비즈니스 행위에 대해 결정적(Deterministic) UUID 기반의 고유 식별자 발급
+                    String uniqueKey = "RESTORE_" + order.getId().toString() + "_" + item.getOptionId().toString();
+                    UUID deterministicEventId = UUID.nameUUIDFromBytes(uniqueKey.getBytes());
+
                     orderOutboxHelper.append(
-                        "ORDER", order.getId().toString(), "STOCK_RESTORE",
-                        new StockRestoreEventPayload(UUID.randomUUID(), item.getOptionId(), item.getQuantity())
+                        "ORDER",
+                        order.getReservationId().toString(), //ORDER_CREATED와 똑같은 카프카 파티션에 들어가게 만들기 위함
+                        "STOCK_RESTORE",
+                        new StockRestoreEventPayload(
+                            deterministicEventId,
+                            item.getOptionId(),
+                            item.getQuantity()
+                        )
                     );
                 }
             } else {
@@ -181,11 +195,19 @@ public class OrderCommandService {
         order.cancel(LocalDate.now());
 
         for (OrderItem item : order.getOrderItems()) {
+            // 동일한 비즈니스 행위에 대해 결정적(Deterministic) UUID 기반의 고유 식별자 발급
+            String uniqueKey = "RESTORE_" + order.getId().toString() + "_" + item.getOptionId().toString();
+            UUID deterministicEventId = UUID.nameUUIDFromBytes(uniqueKey.getBytes());
+
             orderOutboxHelper.append(
                 "ORDER",
-                order.getId().toString(),
+                order.getReservationId().toString(), //ORDER_CREATED와 똑같은 카프카 파티션에 들어가게 만들기 위함
                 "STOCK_RESTORE",
-                new StockRestoreEventPayload(UUID.randomUUID(), item.getOptionId(), item.getQuantity())
+                new StockRestoreEventPayload(
+                    deterministicEventId,
+                    item.getOptionId(),
+                    item.getQuantity()
+                )
             );
             log.info("주문 취소에 따른 재고 복구 Outbox 저장 완료: optionId={}, quantity={}", item.getOptionId(), item.getQuantity());
         }
@@ -213,6 +235,10 @@ public class OrderCommandService {
     public OrderResult getOrder(UUID orderId) {
         Order order = orderRepository.findById(orderId)
             .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다."));
-        return new OrderResult(order.getId(), order.getStatus().name(), order.getOrderName());
+        return new OrderResult(
+            order.getId(),
+            order.getStatus().name(),
+            order.getOrderName()
+        );
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,10 +39,11 @@ server:
 order:
     kafka:
         topic:
-            created: "order.created"
+            # 개별 토픽을 단일 커맨드 토픽(inventory.command)으로 통일
+            created: "inventory.command"
+            stock-restore: "inventory.command"
             approved: "order.approved"
             rejected: "order.rejected"
-            stock-restore: "order.stock-restore.requested"
     outbox:
         max-retries: 3 # 최대 재시도 횟수 설정
 

--- a/src/test/java/com/michelet/order/application/OrderCommandServiceTest.java
+++ b/src/test/java/com/michelet/order/application/OrderCommandServiceTest.java
@@ -182,11 +182,12 @@ class OrderCommandServiceTest {
         UUID orderId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         UUID optionId = UUID.randomUUID();
+        UUID reservationId = UUID.randomUUID(); // 예약 ID 변수 추가
 
         OrderItem item = OrderItem.create(optionId, "테스트상품", new BigDecimal("1000"), 2);
         Order order = Order.create(
             userId,
-            UUID.randomUUID(),
+            reservationId, // 위에서 만든 예약 ID 주입
             UUID.randomUUID(),
             "테스트 주문",
             LocalDate.now().plusDays(1),
@@ -207,7 +208,7 @@ class OrderCommandServiceTest {
         assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
         verify(orderOutboxHelper, times(1)).append(
             eq("ORDER"),
-            eq(orderId.toString()),
+            eq(reservationId.toString()), // 파티션 키가 reservationId로 잘 넘어갔는지 검증
             eq("STOCK_RESTORE"),
             any(StockRestoreEventPayload.class)
         );

--- a/src/test/java/com/michelet/order/application/OrderCommandServiceTest.java
+++ b/src/test/java/com/michelet/order/application/OrderCommandServiceTest.java
@@ -21,6 +21,7 @@ import com.michelet.order.domain.model.ReceivingMethod;
 import com.michelet.order.domain.repository.OrderRepository;
 import com.michelet.order.infrastructure.client.CatalogClient;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -62,6 +63,10 @@ class OrderCommandServiceTest {
     private ArgumentCaptor<Order> orderCaptor;
     @Captor
     private ArgumentCaptor<OrderCreatedEventPayload> payloadCaptor;
+
+    // Outbox Payload 자체 검증을 위한 Captor 인스턴스 주입 선언
+    @Captor
+    private ArgumentCaptor<StockRestoreEventPayload> restorePayloadCaptor;
 
     @Test
     @DisplayName("성공: 다중 품목 주문 시 총 주문 금액이 정확히 계산되고 PENDING 상태로 저장되어야 한다")
@@ -206,12 +211,23 @@ class OrderCommandServiceTest {
 
         // then
         assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
+
+        // 파티션 키, 결정적 UUID 정합성 캡처 검증
         verify(orderOutboxHelper, times(1)).append(
             eq("ORDER"),
             eq(reservationId.toString()), // 파티션 키가 reservationId로 잘 넘어갔는지 검증
             eq("STOCK_RESTORE"),
-            any(StockRestoreEventPayload.class)
+            restorePayloadCaptor.capture()
         );
+
+        StockRestoreEventPayload restorePayload = restorePayloadCaptor.getValue();
+        UUID expectedEventId = UUID.nameUUIDFromBytes(
+            ("RESTORE_" + orderId.toString() + "_" + optionId.toString()).getBytes(StandardCharsets.UTF_8)
+        );
+
+        assertThat(restorePayload.eventId()).isEqualTo(expectedEventId);
+        assertThat(restorePayload.optionId()).isEqualTo(optionId);
+        assertThat(restorePayload.quantity()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 주문 생성 직후 취소 상황에서 발생하던 순서 역전 현상 해결
  - 기존에는 매 이벤트마다 새로운 uuid가 생성되어, 고객의 취소요청과, 재고부족 등의 이유로 인한 재고복원처럼 다른 이유의 재고 복원 요청이 동시에 들어올 경우, 2회 복구가 되는 문제가 있었음
  - 이를 해결하기 위해 Deterministic UUID로 수정했으나, 같은 토픽이 아니라서 때때로 재고 복원이 안 되는 경우가 발생함
  - -> 통합 커맨드 토픽으로 수정


## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #30  \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="769" height="217" alt="스크린샷 2026-05-16 오후 7 31 20" src="https://github.com/user-attachments/assets/af092aa4-0a48-4fed-8691-f01ea1e27bb0" />
<img width="1256" height="615" alt="스크린샷 2026-05-16 오후 7 25 32" src="https://github.com/user-attachments/assets/99e16bf4-bb37-4add-8943-d27938383249" />
<img width="1247" height="357" alt="스크린샷 2026-05-16 오후 7 25 42" src="https://github.com/user-attachments/assets/699c99f0-7628-4abb-af6b-0737bab2ff07" />
<img width="1387" height="215" alt="스크린샷 2026-05-16 오후 7 26 28" src="https://github.com/user-attachments/assets/9cae6cf6-9226-42de-9d30-576011d9fa5e" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 주문 취소·재고 복구 흐름 개선으로 취소 처리 안정성 및 일관성 향상(재고 복구 이벤트 식별·집계 방식 개선).

* **Tests**
  * 취소 멱등성, 즉시 취소/경합 시나리오 및 재고 합산 검증 테스트 추가로 운영 신뢰성 강화.

* **Chores**
  * 메시지 토픽 매핑 정비로 브로커 연계 방식 단순화(커맨드 토픽 통합).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/order-service/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->